### PR TITLE
- Expanded the number of parameters for client security configuration.

### DIFF
--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -17,15 +17,17 @@ def run_cmd(ctx):
 @click.option('-t', '--token', required=True)
 @click.option('-n', '--name', required=False, default=None)
 @click.option('-i', '--client_id', required=False)
+@click.option('-s', '--secure', required=False, default=True)
+@click.option('-v', '--preshared-cert', required=False, default=False)
+@click.option('-v', '--verify-cert', required=False, default=False)
 @click.pass_context
-def client_cmd(ctx, discoverhost, discoverport, token, name, client_id):
-
+def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, secure, preshared_cert, verify_cert):
     if name == None:
         import uuid
         name = str(uuid.uuid4())
-    
+
     config = {'discover_host': discoverhost, 'discover_port': discoverport, 'token': token, 'name': name,
-              'client_id': client_id}
+              'client_id': client_id, 'secure': secure, 'preshared_cert': preshared_cert, 'verify_cert': verify_cert}
 
     from fedn.client import Client
     client = Client(config)
@@ -54,11 +56,11 @@ def reducer_cmd(ctx, discoverhost, discoverport, token, name):
 @click.option('-h', '--hostname', required=True)
 @click.option('-i', '--port', required=True)
 @click.option('-s', '--secure', required=False, default=True)
-@click.option('-c', '--max_clients', required=False,default=8)
+@click.option('-c', '--max_clients', required=False, default=8)
 @click.pass_context
-def combiner_cmd(ctx, discoverhost, discoverport, token, name, hostname, port, secure,max_clients):
+def combiner_cmd(ctx, discoverhost, discoverport, token, name, hostname, port, secure, max_clients):
     config = {'discover_host': discoverhost, 'discover_port': discoverport, 'token': token, 'myhost': hostname,
-              'myport': port, 'myname': name, 'secure': secure,'max_clients':max_clients}
+              'myport': port, 'myname': name, 'secure': secure, 'max_clients': max_clients}
 
     from fedn.combiner import Combiner
     combiner = Combiner(config)

--- a/fedn/fedn/client.py
+++ b/fedn/fedn/client.py
@@ -25,7 +25,10 @@ class Client:
                                          config['discover_port'],
                                          config['token'],
                                          config['name'],
-                                         config['client_id'])
+                                         config['client_id'],
+                                         secure=config['secure'],
+                                         preshared_cert=['preshared_cert'],
+                                         verify_cert=config['verify_cert'])
         self.name = config['name']
 
         self.started_at = datetime.now()

--- a/fedn/fedn/common/net/connect.py
+++ b/fedn/fedn/common/net/connect.py
@@ -21,6 +21,11 @@ from fedn.common.security.certificate import Certificate
 class ConnectorClient:
 
     def __init__(self, host, port, token, name, id=None, secure=True, preshared_cert=True, verify_cert=False):
+
+        if not verify_cert:
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         self.host = host
         self.port = port
         self.token = token
@@ -49,7 +54,8 @@ class ConnectorClient:
     def assign(self):
 
         try:
-            retval = r.get("{}?name={}".format(self.connect_string + '/assign', self.name), verify=str(self.certificate),
+            cert = str(self.certificate) if self.verify_cert else False
+            retval = r.get("{}?name={}".format(self.connect_string + '/assign', self.name), verify=cert,
                            headers={'Authorization': 'Token {}'.format(self.token)})
         except Exception as e:
             print('***** {}'.format(e),flush=True)
@@ -67,12 +73,18 @@ class ConnectorClient:
 class ConnectorCombiner:
 
     def __init__(self, host, port, myhost, myport, token, name, secure=True, preshared_cert=True, verify_cert=False):
+
+        if not verify_cert:
+            import urllib3
+            urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
         self.host = host
         self.port = port
         self.myhost = myhost
         self.myport = myport
         self.token = token
         self.name = name
+        self.verify_cert = verify_cert
         # self.state = State.Disconnected
         self.secure = secure
         if not secure:
@@ -97,11 +109,12 @@ class ConnectorCombiner:
     def announce(self):
 
         try:
+            cert = str(self.certificate) if self.verify_cert else False
             retval = r.get("{}?name={}&address={}&port={}".format(self.connect_string + '/add',
                                                                   self.name,
                                                                   self.myhost,
                                                                   self.myport),
-                           verify=str(self.certificate),
+                           verify=cert,
                            headers={'Authorization': 'Token {}'.format(self.token)})
         except Exception as e:
             # self.state = State.Disconnected
@@ -113,190 +126,3 @@ class ConnectorCombiner:
             return Status.Assigned, retval.json()
 
         return Status.Unassigned, None
-
-
-"""
-    def connect(self):
-
-        try:
-            retval = r.get("{}{}/".format(self.connect_string + '/client/', self.name),
-                           headers={'Authorization': 'Token {}'.format(self.token)})
-        except Exception as e:
-            self.state = State.Disconnected
-            return self.state
-
-        if retval.status_code != 200:
-
-            payload = {'name': self.name, 'status': "R", 'user': self.id}
-            retval = r.post(self.connect_string + '/client/', data=payload,
-                            headers={'Authorization': 'Token {}'.format(self.token)})
-            # print("status is {} and payload {}".format(retval.status_code, retval.text), flush=True)
-            if retval.status_code >= 200 or retval.status_code < 204:
-                self.state = State.Connected
-            else:
-                self.state = State.Disconnected
-        else:
-            self.state = State.Connected
-
-        return self.state
-
-    def update_status(self, status):
-        # print("\n\nUpdate status", flush=True)
-        payload = {'status': status}
-        retval = r.patch("{}{}/".format(self.connect_string + '/client/', self.name), data=payload,
-                         headers={'Authorization': 'Token {}'.format(self.token)})
-
-        # print("SETTING UPDATE< WHAT HAPPENS {} {}".format(retval.status_code, retval.text), flush=True)
-        if retval.status_code >= 200 or retval.status_code < 204:
-            self.state = State.Connected
-        else:
-            self.state = State.Disconnected
-
-        newstatus = None
-
-        retval = r.get("{}{}/".format(self.connect_string + '/client/', self.name),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        payload = retval.json()
-        try:
-            newstatus = payload['status']
-        except Exception as e:
-            print("Error getting payload {}".format(e))
-            self.state = State.Error
-
-        return newstatus
-
-    def check_status(self):
-        print("\n\nCheck status", flush=True)
-        status = None
-
-        retval = r.get("{}{}/".format(self.connect_string + '/client/', self.name),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        payload = retval.json()
-        # print("Got payload {}".format(payload), flush=True)
-        try:
-            status = payload['status']
-        except Exception as e:
-            print("Error getting payload {}".format(e))
-            self.state = State.Error
-
-        return status, self.state
-
-    def get_config(self):
-        retval = r.get("{}{}/".format(self.connect_string + '/client/', self.name),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        payload = retval.json()
-        print("GOT CONFIG: {}".format(payload))
-        retval = r.get("{}?id={}".format(self.connect_string + '/combiner/', payload['combiner']),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        combiner_payload = retval.json()[0]
-        print("GOT HOST PORT ETC SET TO {}".format(combiner_payload))
-
-        return combiner_payload, self.state
-
-
-"""
-"""
-class DiscoveryCombinerConnect(ConnectorClient):
-
-    def __init__(self, host, port, token, myhost, myport, myname):
-        super().__init__(host, port, token, myname)
-        self.connect_string = "http://{}:{}".format(self.host, self.port)
-        self.myhost = myhost
-        self.myport = myport
-        self.myname = myname
-        print("\n\nsetting the connection string to {}\n\n".format(self.connect_string), flush=True)
-
-    def connect(self):
-
-        retval = r.get("{}{}/".format(self.connect_string + '/combiner/', self.myname),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        if 200 <= retval.status_code < 204:
-            if retval.json()['status'] != 'R':
-                print("Recovering from previous state. Resetting to Ready\n\n", flush=True)
-                status = 'R'
-                payload = {'status': status}
-                retval = r.patch("{}{}/".format(self.connect_string + '/combiner/', self.myname), data=payload,
-                                 headers={'Authorization': 'Token {}'.format(self.token)})
-
-        if retval.status_code != 200:
-
-            # print("Got payload {}".format(ret), flush=True)
-            payload = {'name': self.myname, 'port': self.myport, 'host': self.myhost, 'status': "S", 'user': 1}
-            retval = r.post(self.connect_string + '/combiner/', data=payload,
-                            headers={'Authorization': 'Token {}'.format(self.token)})
-            print("status is {} and payload {}".format(retval.status_code, retval.text), flush=True)
-            if 200 <= retval.status_code < 204:
-                self.state = State.Connected
-            else:
-                self.state = State.Disconnected
-        else:
-            self.state = State.Connected
-
-        return self.state
-
-    def update_status(self, status):
-        print("\n\nUpdate status", flush=True)
-        payload = {'status': status}
-        retval = r.patch("{}{}/".format(self.connect_string + '/combiner/', self.myname), data=payload,
-                         headers={'Authorization': 'Token {}'.format(self.token)})
-
-        # print("SETTING UPDATE< WHAT HAPPENS {} {}".format(retval.status_code, retval.text), flush=True)
-        if 200 <= retval.status_code < 204:
-            self.state = State.Connected
-        else:
-            self.state = State.Disconnected
-
-        newstatus = None
-
-        retval = r.get("{}{}/".format(self.connect_string + '/combiner/', self.myname),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        payload = retval.json()
-        try:
-            newstatus = payload['status']
-        except Exception as e:
-            print("Error getting payload {}".format(e))
-            self.state = State.Error
-
-        return newstatus
-
-    def check_status(self):
-        print("\n\nCheck status", flush=True)
-        status = None
-
-        retval = r.get("{}{}/".format(self.connect_string + '/combiner/', self.myname),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        payload = retval.json()
-        print("Got payload {}".format(payload), flush=True)
-        try:
-            status = payload['status']
-        except Exception as e:
-            print("Error getting payload {}".format(e))
-            self.state = State.Error
-
-        return status, self.state
-
-    def get_combiner_config(self):
-        retval = r.get("{}{}/".format(self.connect_string + '/combiner/', self.myname),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        payload = retval.json()
-        print("GOT CONFIG: {}".format(payload))
-
-        return payload, self.state
-
-    def get_config(self):
-        retval = r.get("{}{}/".format(self.connect_string + '/configuration/', self.myname),
-                       headers={'Authorization': 'Token {}'.format(self.token)})
-
-        payload = retval.json()
-        print("GOT CONFIG: {}".format(payload))
-
-        return payload, self.state
-"""

--- a/fedn/fedn/common/security/certificate.py
+++ b/fedn/fedn/common/security/certificate.py
@@ -33,7 +33,7 @@ class Certificate:
         cert.get_subject().O = "Development Key"
         cert.get_subject().OU = "Development Key"
         cert.get_subject().CN = self.name  # gethostname()
-        cert.set_serial_number(1000)
+        cert.set_serial_number(1002)
 
         cert.gmtime_adj_notBefore(0)
         cert.gmtime_adj_notAfter(31 * 24 * 60 * 60)


### PR DESCRIPTION
1. Added additional parameters to configure cert on client runtime
```bash
--secure=True/False
--preshared-cert=CertName/None
--verify-cert=True/False
```

on option verify-cert=false
It will also suppress urllib3 warning about NoValidation of Cert.