### PR TITLE
Change amount of data used by each client

### DIFF
--- a/test/mnist/client/train.py
+++ b/test/mnist/client/train.py
@@ -52,7 +52,7 @@ def train(model,data,sample_fraction):
 
 if __name__ == '__main__':
     model = krm.load_model(sys.argv[1])
-    model = train(model,'../data/train.csv',sample_fraction=0.01)
+    model = train(model,'../data/train.csv',sample_fraction=0.001)
     model.save(sys.argv[2])
 
 


### PR DESCRIPTION
Changes the default data amount in MNIST-client. Makes convergence noisier and the example more interesting/pedagogical.