### PR TITLE
Reset base image user to default

### DIFF
--- a/components/client/Dockerfile
+++ b/components/client/Dockerfile
@@ -1,13 +1,7 @@
 FROM morganekmefjord/basesci:latest
-RUN adduser --disabled-password --gecos '' fednuser \
-    && adduser fednuser sudo \
-    && echo '%sudo ALL=(ALL:ALL) ALL' >> /etc/sudoers
-
 
 RUN mkdir -p /app/client
 RUN mkdir /app/certs
 COPY fedn /app/fedn
 RUN pip install -e /app/fedn
-RUN chown -R fednuser /app
-USER fednuser
 WORKDIR /app


### PR DESCRIPTION
Set the base image user to default to ensure host/container compliant uid/gid. This will enable mounted dirs to be writable where required without explicitily setting permissions to rwx or using the container uid/gid.