### PR TITLE
Introduce custom baseimage override

### DIFF
--- a/components/client/Dockerfile
+++ b/components/client/Dockerfile
@@ -1,13 +1,9 @@
-FROM morganekmefjord/basesci:latest
-RUN adduser --disabled-password --gecos '' fednuser \
-    && adduser fednuser sudo \
-    && echo '%sudo ALL=(ALL:ALL) ALL' >> /etc/sudoers
-
+ARG baseimage="python:3.8"
+FROM ${baseimage}
 
 RUN mkdir -p /app/client
 RUN mkdir /app/certs
 COPY fedn /app/fedn
+RUN pip install numpy
 RUN pip install -e /app/fedn
-RUN chown -R fednuser /app
-USER fednuser
 WORKDIR /app

--- a/tensorflow.yaml
+++ b/tensorflow.yaml
@@ -1,0 +1,19 @@
+version: '3.7'
+services:
+  client:
+    build:
+      context: .
+      dockerfile: components/client/Dockerfile
+      args:
+        baseimage: "tensorflow/tensorflow:latest"
+        #baseimage: morganekmefjord/basesci:latest
+  reducer:
+    #environment:
+    #  - BASEIMAGE="tensorflow/tensorflow:latest"
+    build:
+      context: .
+      dockerfile: components/client/Dockerfile
+
+      args:
+        baseimage: "tensorflow/tensorflow:latest"
+        #baseimage: morganekmefjord/basesci:latest


### PR DESCRIPTION
To streamline better test projects In this suggested commit there are a new structure to allow for overriding of parameters.
```yaml
version: '3.7'
services:
  client:
    build:
      context: .
      dockerfile: components/client/Dockerfile
      args:
        baseimage: "tensorflow/tensorflow:latest"
```
Illustrated by an example
```bash
docker-compose -f docker-compose.yaml -f reducer.yaml -f combiner.yaml -f client.yaml **-f tensorflow.yaml** --build --scale client=5
```
where tensorflow.yaml in this example is overriding the BASEIMAGE variable to the Dockerimage and instructs which base image to initiate the client image from.


In this sense the tests we construct can have the same basic structure but depending on framework selected can _inherit_ base image from for example tensorflow to ensure the execution context is present.

