### PR TITLE
Bug fix: filename was dict when setting context from config file

### DIFF
--- a/fedn/fedn/clients/reducer/statestore/mongoreducerstatestore.py
+++ b/fedn/fedn/clients/reducer/statestore/mongoreducerstatestore.py
@@ -70,7 +70,7 @@ class MongoReducerStateStore(ReducerStateStore):
                             # TODO Fix the ugly latering of indirection due to a bug in secure_filename returning an object with filename as attribute
                             # TODO fix with unboxing of value before storing and where consuming.
                             self.control.config.update({'key': 'package'},
-                                                        {'$set': {'filename': {'filename': control['context']}}}, True)
+                                                        {'$set': {'filename': control['context']}}, True)
                         if "helper" in control:
                             self.set_framework(control['helper'])
 

--- a/test/mnist-keras/Dockerfile
+++ b/test/mnist-keras/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:3.8.5
 RUN pip install -e git://github.com/scaleoutsystems/fedn.git@master#egg=fedn\&subdirectory=fedn
-COPY fedn-network.yaml /app/ 
 COPY requirements.txt /app/
 WORKDIR /app
 RUN pip install -r requirements.txt
+COPY fedn-network.yaml /app/ 
+
+


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description

Fixes bug when setting context from reducer settings file.
Changes order in mnist-keras client dockerfile (faster rebuild when only changing fedn-network.yaml)

## Types of changes

What types of changes does your code introduce to FEDn?

- [ ] Hotfix (fixing a critical bug in production)
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request

## Further comments

Anything else you think we should know before merging your code!
