### PR TITLE
issue #260: combiner startup log fixed

### DIFF
--- a/fedn/fedn/combiner.py
+++ b/fedn/fedn/combiner.py
@@ -516,7 +516,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
     def run(self):
         import signal
-        print("COMBINER: {} initialized".format(self.id), flush=True)
+        print("COMBINER: {} started, ready for requests. ".format(self.id), flush=True)
         try:
             while True:
                 signal.pause()

--- a/fedn/fedn/combiner.py
+++ b/fedn/fedn/combiner.py
@@ -516,7 +516,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
     def run(self):
         import signal
-        print("COMBINER:starting {}".format(self.id), flush=True)
+        print("COMBINER: {} initialized".format(self.id), flush=True)
         try:
             while True:
                 signal.pause()


### PR DESCRIPTION
## Status

- [O ] Ready
- [ ] Draft
- [ ] Hold

## Description

This PR is to fix [Issue#260](https://github.com/scaleoutsystems/fedn/issues/260), which points that the startup log of the combiners is not correctly displayed. 

The combiner has been initialized before the printing statement runs, however, it prints that "the combiner is starting", which is not proper and makes users confusing.  

## Types of changes

What types of changes does your code introduce to FEDn?

- [ ] Hotfix (fixing a critical bug in production)
- [O] Bugfix
- [ ] New feature
- [ ] Documentation update

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
- [O] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [O] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request

## Further comments

Anything else you think we should know before merging your code!
