### PR TITLE
Supersedes: Undefined varibale to_path in PackageRuntime.dispatcher (Issue/#288)

### DIFF
--- a/fedn/fedn/common/control/package.py
+++ b/fedn/fedn/common/control/package.py
@@ -212,15 +212,10 @@ class PackageRuntime:
         :param run_path:
         :return:
         """
-        dispatch_dir = self.dir
         from_path = os.path.join(os.getcwd(), 'client')
-        import time
-        dirname = time.strftime("%Y%m%d-%H%M%S")
-
+        
         from distutils.dir_util import copy_tree
         copy_tree(from_path, run_path)
-
-        os.chdir(run_path)
 
         try:
             cfg = None

--- a/fedn/fedn/common/control/package.py
+++ b/fedn/fedn/common/control/package.py
@@ -219,7 +219,7 @@ class PackageRuntime:
 
         try:
             cfg = None
-            with open(os.path.join(to_path, 'fedn.yaml'), 'rb') as config_file:
+            with open(os.path.join(run_path, 'fedn.yaml'), 'rb') as config_file:
                 import yaml
                 cfg = yaml.safe_load(config_file.read())
                 self.dispatch_config = cfg


### PR DESCRIPTION
This PR supersedes #289 because of build failure caused by invalid tag name containing hashtag. Branch has been renamed to
issue/288
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description
Fixes #288, also cleaned up unused variables.

## Types of changes

What types of changes does your code introduce to FEDn?

- [ ] Hotfix (fixing a critical bug in production)
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request

## Further comments

Tested with mnist-keras case, should be tested on a case where fedn.yaml is not default. Suggestion on a case? 

Anything else you think we should know before merging your code!
