### PR TITLE
Robust server side stream RPCs, resolves #329

### DIFF
--- a/fedn/fedn/client.py
+++ b/fedn/fedn/client.py
@@ -271,7 +271,6 @@ class Client:
         r.sender.name = self.name
         r.sender.role = fedn.WORKER
         metadata = [('client', r.sender.name)]
-        import time
         while True:
             try:
                 for request in self.orchestrator.ModelUpdateRequestStream(r, metadata=metadata):
@@ -287,8 +286,9 @@ class Client:
                 timeout = 5
                 print("CLIENT __listen_to_model_update_request_stream: GRPC ERROR {} retrying in {}..".format(
                     status_code.name, timeout), flush=True)
-                import time
                 time.sleep(timeout)
+            except:
+                raise
 
     def _listen_to_model_validation_request_stream(self):
         """Subscribe to the model validation request stream. """
@@ -315,7 +315,6 @@ class Client:
 
     def process_request(self):
         """Process training and validation tasks. """
-
         while True:
             (task_type, request) = self.inbox.get()
             if task_type == 'train':
@@ -377,8 +376,6 @@ class Client:
 
                 self.state = ClientState.idle
                 self.inbox.task_done()
-
-
 
     def _process_training_request(self, model_id):
         """Process a training (model update) request. 

--- a/fedn/fedn/combiner.py
+++ b/fedn/fedn/combiner.py
@@ -52,6 +52,8 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
     """ Communication relayer. """
 
     def __init__(self, connect_config):
+
+        # Holds client queues 
         self.clients = {}
 
         self.modelservice = ModelService()
@@ -505,8 +507,11 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
         self._send_status(status)
 
-        while True:
-            yield q.get()
+        while context.is_active():
+            try:
+                yield q.get(timeout=1.0)
+            except queue.Empty:
+                pass 
 
     def ModelUpdateRequestStream(self, response, context):
         """ A server stream RPC endpoint. Messages from client stream. """
@@ -528,8 +533,12 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
         self._send_status(status)
 
-        while True:
-            yield q.get()
+        while context.is_active():
+            try:
+                yield q.get(timeout=1.0)
+            except queue.Empty:
+                pass 
+           
 
     def ModelValidationStream(self, update, context):
         """
@@ -549,8 +558,11 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
         self._send_status(status)
 
-        while True:
-            yield q.get()
+        while context.is_active():
+            try:
+                yield q.get(timeout=1.0)
+            except queue.Empty:
+                pass 
 
     def ModelValidationRequestStream(self, response, context):
         """ A server stream RPC endpoint. Messages from client stream. """
@@ -568,8 +580,11 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
         self._send_status(status)
 
-        while True:
-            yield q.get()
+        while context.is_active():
+            try:
+                yield q.get(timeout=1.0)
+            except queue.Empty:
+                pass 
 
     def SendModelUpdateRequest(self, request, context):
         """ Send a model update request. """


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description

Makes the server side unary stream RPCs clean up/exit when there is an uncontrolled client failure. Resolves issue #329 

## Types of changes

What types of changes does your code introduce to FEDn?

- [ ] Hotfix (fixing a critical bug in production)
- [x] Bugfix
- [ ] New feature
- [ ] Documentation update

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [x] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [x] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request

## Further comments

Anything else you think we should know before merging your code!
