### PR TITLE
Sk 56

### DIFF
--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -49,7 +49,7 @@ def check_helper_config_file(config):
     try:
         helper = control["helper"]
     except KeyError:
-        print("--remote was set to False, but no helper was found in --init settings file.", flush=True)
+        print("--local-package was used, but no helper was found in --init settings file.", flush=True)
         exit(-1)
     return helper
 

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -71,7 +71,7 @@ def run_cmd(ctx):
 @click.option('-t', '--token', required=False)
 @click.option('-n', '--name', required=False, default="client" + str(uuid.uuid4())[:8])
 @click.option('-i', '--client_id', required=False)
-@click.option('-r', '--remote', required=False, default=True, help='Enable remote configured execution context')
+@click.option('-l', '--local-package', required=False, default=False, help='Enable local compute package')
 @click.option('-u', '--dry-run', required=False, default=False)
 @click.option('-s', '--secure', required=False, default=True)
 @click.option('-pc', '--preshared-cert', required=False, default=False)
@@ -86,7 +86,7 @@ def run_cmd(ctx):
 @click.option('--heartbeat-interval',required=False, default=2)
 @click.option('--reconnect-after-missed-heartbeat',required=False, default=30)
 @click.pass_context
-def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, remote, dry_run, secure, preshared_cert,
+def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, local_package, dry_run, secure, preshared_cert,
                verify_cert, preferred_combiner, validator, trainer, init, logfile, heartbeat_interval, reconnect_after_missed_heartbeat):
     """
 
@@ -108,6 +108,7 @@ def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, remote, 
     :param reconnect_after_missed_heartbeat
     :return:
     """
+    remote = False if local_package else True
     config = {'discover_host': discoverhost, 'discover_port': discoverport, 'token': token, 'name': name,
               'client_id': client_id, 'remote_compute_context': remote, 'dry_run': dry_run, 'secure': secure,
               'preshared_cert': preshared_cert, 'verify_cert': verify_cert, 'preferred_combiner': preferred_combiner,
@@ -149,12 +150,12 @@ def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, remote, 
 @click.option('-d', '--discoverhost', required=False)
 @click.option('-p', '--discoverport', required=False, default='8090')
 @click.option('-t', '--token', required=False, default=None)
-@click.option('-r', '--remote', required=False, default=True, help='Enable remote configured execution context')
+@click.option('-l', '--local-package', required=False, default=False, help='Enable local compute package')
 @click.option('-n', '--name', required=False, default="reducer" + str(uuid.uuid4())[:8])
 @click.option('-i', '--init', required=True, default=None,
               help='Set to a filename to (re)init reducer from file state.')
 @click.pass_context
-def reducer_cmd(ctx, discoverhost, discoverport, token, remote, name, init):
+def reducer_cmd(ctx, discoverhost, discoverport, token, local_package, name, init):
     """
 
     :param ctx:
@@ -164,6 +165,7 @@ def reducer_cmd(ctx, discoverhost, discoverport, token, remote, name, init):
     :param name:
     :param init:
     """
+    remote = False if local_package else True
     config = {'discover_host': discoverhost, 'discover_port': discoverport, 'token': token, 'name': name, 
               'remote_compute_context': remote, 'init': init}
 

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -71,7 +71,7 @@ def run_cmd(ctx):
 @click.option('-t', '--token', required=False)
 @click.option('-n', '--name', required=False, default="client" + str(uuid.uuid4())[:8])
 @click.option('-i', '--client_id', required=False)
-@click.option('-l', '--local-package', required=False, default=False, help='Enable local compute package')
+@click.option('-l', '--local-package', is_flag=True, help='Enable local compute package')
 @click.option('-u', '--dry-run', required=False, default=False)
 @click.option('-s', '--secure', required=False, default=True)
 @click.option('-pc', '--preshared-cert', required=False, default=False)
@@ -148,9 +148,9 @@ def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, local_pa
 
 @run_cmd.command('reducer')
 @click.option('-d', '--discoverhost', required=False)
-@click.option('-p', '--discoverport', required=False, default='8090')
+@click.option('-p', '--discoverport', required=False, default='8090', show_default=True)
 @click.option('-t', '--token', required=False, default=None)
-@click.option('-l', '--local-package', required=False, default=False, help='Enable local compute package')
+@click.option('-l', '--local-package', is_flag=True, help='Enable local compute package')
 @click.option('-n', '--name', required=False, default="reducer" + str(uuid.uuid4())[:8])
 @click.option('-i', '--init', required=True, default=None,
               help='Set to a filename to (re)init reducer from file state.')

--- a/fedn/cli/tests/tests.py
+++ b/fedn/cli/tests/tests.py
@@ -1,50 +1,90 @@
-import pytest
+from telnetlib import COM_PORT_OPTION
+import unittest
+from unittest.mock import MagicMock, patch
+import yaml
+from click.testing import CliRunner
 from uuid import UUID
-from ..run_cmd import set_token
+from ..run_cmd import set_token, reducer_cmd, check_helper_config_file
 
-INIT_FILE_REDUCER = {
-    "network_id": "fedn-test-network",
-    "token": "fedn_token",
-    "control":{
-        "state": "idle",
-        "helper": "keras",
-    },
-    "statestore":{
-        "type": "MongoDB",
-        "mongo_config": {
-            "username": "fedn_admin",
-            "password": "password",
-            "host": "mongo",
-            "port": "6534"
+class TestReducerCLI(unittest.TestCase):
+
+    def setUp(self):
+        self.runner = CliRunner()
+        self.INIT_FILE_REDUCER = {
+            "network_id": "fedn-test-network",
+            "token": "fedn_token",
+            "control":{
+                "state": "idle",
+                "helper": "keras",
+            },
+            "statestore":{
+                "type": "MongoDB",
+                "mongo_config": {
+                    "username": "fedn_admin",
+                    "password": "password",
+                    "host": "mongo",
+                    "port": "6534"
+                }
+            },
+            "storage":{
+                "storage_type": "S3",
+                "storage_config":{
+                    "storage_hostname": "minio",
+                    "storage_port": "9000",
+                    "storage_access_key": "fedn_admin",
+                    "storage_secret_key": "password",
+                    "storage_bucket": "fedn-models",
+                    "context_bucket": "fedn-context",
+                    "storage_secure_mode": "False"
+                }
+            }
         }
-    },
-    "storage":{
-        "storage_type": "S3",
-        "storage_config":{
-            "storage_hostname": "minio",
-            "storage_port": "9000",
-            "storage_access_key": "fedn_admin",
-            "storage_secret_key": "password",
-            "storage_bucket": "fedn-models",
-            "context_bucket": "fedn-context",
-            "storage_secure_mode": "False"
-        }
-    }
-}
 
-def test_set_token():
-    TOKEN_FLAG = "some-test-token"
-    TOKEN_INIT = "fedn_token"
+    def test_set_token(self):
+        TOKEN_FLAG = "some-test-token"
+        TOKEN_INIT = "fedn_token"
+        
+        assert set_token(self.INIT_FILE_REDUCER, TOKEN_FLAG) == TOKEN_FLAG
+        assert set_token(self.INIT_FILE_REDUCER, None) == TOKEN_INIT
+        assert set_token(self.INIT_FILE_REDUCER, "") == TOKEN_INIT
+        
+        COPY_INIT_FILE =  self.INIT_FILE_REDUCER
+        del COPY_INIT_FILE["token"]
+        assert set_token(COPY_INIT_FILE, TOKEN_FLAG) == TOKEN_FLAG
+        
+        TOKEN_UUID = set_token(COPY_INIT_FILE, None)
+        uuid_obj = UUID(TOKEN_UUID, version=4)
+        assert str(uuid_obj) == TOKEN_UUID
     
-    assert set_token(INIT_FILE_REDUCER, TOKEN_FLAG) == TOKEN_FLAG
-    assert set_token(INIT_FILE_REDUCER, None) == TOKEN_INIT
-    assert set_token(INIT_FILE_REDUCER, "") == TOKEN_INIT
+    @unittest.skip
+    def test_get_statestore_config_from_file(self):
+        pass
     
-    COPY_INIT_FILE =  INIT_FILE_REDUCER
-    del COPY_INIT_FILE["token"]
-    assert set_token(COPY_INIT_FILE, TOKEN_FLAG) == TOKEN_FLAG
-    
-    TOKEN_UUID = set_token(COPY_INIT_FILE, None)
-    uuid_obj = UUID(TOKEN_UUID, version=4)
-    assert str(uuid_obj) == TOKEN_UUID
 
+    # def test_reducer_cmd_remote(self):
+        
+    #     with self.runner.isolated_filesystem():
+            
+    #         COPY_INIT_FILE = self.INIT_FILE_REDUCER
+    #         del COPY_INIT_FILE["control"]["helper"]
+
+    #         with open('settings.yaml', 'w') as f:
+    #             f.write(yaml.dump(COPY_INIT_FILE))        
+            
+    #         result = self.runner.invoke(reducer_cmd, ['--remote', False, '--init',"settings.yaml"])
+    #         self.assertEqual(result.output, "--remote was set to False, but no helper was found in --init settings file: settings.yaml\n")
+    #         self.assertEqual(result.exit_code, -1)
+
+    def test_check_helper_config_file(self):
+        
+        self.assertEqual(check_helper_config_file(self.INIT_FILE_REDUCER), "keras")
+        
+        COPY_INIT_FILE = self.INIT_FILE_REDUCER
+        del COPY_INIT_FILE["control"]["helper"]
+        
+        with self.assertRaises(SystemExit):
+            helper = check_helper_config_file(COPY_INIT_FILE)
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fedn/fedn/client.py
+++ b/fedn/fedn/client.py
@@ -6,6 +6,7 @@ import uuid
 import tempfile
 import threading, queue
 import time
+from aiohttp import client
 
 import grpc
 
@@ -59,6 +60,7 @@ class Client:
                                          config['discover_port'],
                                          config['token'],
                                          config['name'],
+                                         config['remote_compute_context'],
                                          config['preferred_combiner'],
                                          config['client_id'],
                                          secure=config['secure'],
@@ -202,6 +204,9 @@ class Client:
             if status == Status.UnAuthorized:
                 print(response, flush=True)
                 sys.exit("Exiting: Unauthorized")
+            if status == Status.UnMatchedConfig:
+                print(response, flush=True)
+                sys.exit("Exiting: UnMatchedConfig")
             time.sleep(5)
             print(".", end=' ', flush=True)
         
@@ -238,6 +243,8 @@ class Client:
         print("Client: {} connected {} to {}:{}".format(self.name,
                                                         "SECURED" if client_config['certificate'] else "INSECURE",
                                                         client_config['host'], client_config['port']), flush=True)
+        
+        print("Client: Using {} compute package.".format(client_config["package"]))
 
     def _disconnect(self):
         self.channel.close()

--- a/fedn/fedn/clients/reducer/statestore/mongoreducerstatestore.py
+++ b/fedn/fedn/clients/reducer/statestore/mongoreducerstatestore.py
@@ -233,9 +233,14 @@ class MongoReducerStateStore(ReducerStateStore):
 
         :return:
         """
-        ret = self.control.config.find({'key': 'package'})
+        ret = self.control.config.find_one({'key': 'package'})
+        #if local compute package used, then 'package' is None
+        if not ret:
+            #get framework from round_config instead
+            ret = self.control.config.find_one({'key': 'round_config'})
+        print('FRAMEWORK:', ret)
         try:
-            retcheck = ret[0]['helper']
+            retcheck = ret['helper']
             if retcheck == '' or retcheck == ' ':  # ugly check for empty string
                 return None
             return retcheck

--- a/fedn/fedn/tests/test_reducer_service.py
+++ b/fedn/fedn/tests/test_reducer_service.py
@@ -12,7 +12,8 @@ class TestInit(unittest.TestCase):
             'discover_host': 'TEST_HOST',
             'name': 'TEST_NAME',
             'discover_port': 1111,
-            'token': None
+            'token': None,
+            'remote_compute_context': True
         }
         restservice = ReducerRestService(CONFIG, mock_control, None)
         self.assertEqual(restservice.name, 'TEST_HOST')
@@ -24,7 +25,8 @@ class TestInit(unittest.TestCase):
             'discover_host': None,
             'name': 'TEST_NAME',
             'discover_port': 1111,
-            'token': None
+            'token': None,
+            'remote_compute_context': True
         }
         restservice = ReducerRestService(CONFIG, mock_control, None)
         self.assertEqual(restservice.name, 'TEST_NAME')
@@ -35,7 +37,8 @@ class TestInit(unittest.TestCase):
             'discover_host': 'TEST_HOST',
             'name': 'TEST_NAME',
             'discover_port': 1111,
-            'token': None
+            'token': None,
+            'remote_compute_context': True
         }
         restservice = ReducerRestService(CONFIG, mock_control, None)
         self.assertEqual(restservice.network_id, 'TEST_NAME-network')
@@ -43,14 +46,15 @@ class TestInit(unittest.TestCase):
 class TestChecks(unittest.TestCase):
     @patch('fedn.clients.reducer.control.ReducerControl')
     def setUp(self, mock_control):
-        self.config = {
+        CONFIG = {
             'discover_host': 'TEST_HOST',
             'name': 'TEST_NAME',
             'discover_port': 1111,
-            'token': None
+            'token': None,
+            'remote_compute_context': True
         }
 
-        self.restservice = ReducerRestService(self.config, mock_control, None)
+        self.restservice = ReducerRestService(CONFIG, mock_control, None)
 
     def test_check_compute_package(self):
 
@@ -65,6 +69,10 @@ class TestChecks(unittest.TestCase):
         self.restservice.control.get_compute_context.return_value = ''
         retval = self.restservice.check_compute_context()
         self.assertFalse(retval)
+
+        self.restservice.remote_compute_context = False 
+        retval = self.restservice.check_compute_context()
+        self.assertTrue(retval)
 
     def test_check_initial_model(self):
 

--- a/fedn/fedn/tests/test_reducer_service.py
+++ b/fedn/fedn/tests/test_reducer_service.py
@@ -1,0 +1,85 @@
+import unittest
+from fedn.clients.reducer.restservice import ReducerRestService
+from fedn.clients.reducer.state import ReducerState
+from unittest.mock import MagicMock, patch
+
+
+class TestInit(unittest.TestCase):
+
+    @patch('fedn.clients.reducer.control.ReducerControl')
+    def test_discover_host(self, mock_control):
+        CONFIG = {
+            'discover_host': 'TEST_HOST',
+            'name': 'TEST_NAME',
+            'discover_port': 1111,
+            'token': None
+        }
+        restservice = ReducerRestService(CONFIG, mock_control, None)
+        self.assertEqual(restservice.name, 'TEST_HOST')
+        self.assertEqual(restservice.network_id, 'TEST_NAME-network')
+        
+    @patch('fedn.clients.reducer.control.ReducerControl')
+    def test_name(self, mock_control):
+        CONFIG = {
+            'discover_host': None,
+            'name': 'TEST_NAME',
+            'discover_port': 1111,
+            'token': None
+        }
+        restservice = ReducerRestService(CONFIG, mock_control, None)
+        self.assertEqual(restservice.name, 'TEST_NAME')
+    
+    @patch('fedn.clients.reducer.control.ReducerControl')
+    def test_network_id(self, mock_control):
+        CONFIG = {
+            'discover_host': 'TEST_HOST',
+            'name': 'TEST_NAME',
+            'discover_port': 1111,
+            'token': None
+        }
+        restservice = ReducerRestService(CONFIG, mock_control, None)
+        self.assertEqual(restservice.network_id, 'TEST_NAME-network')
+
+class TestChecks(unittest.TestCase):
+    @patch('fedn.clients.reducer.control.ReducerControl')
+    def setUp(self, mock_control):
+        self.config = {
+            'discover_host': 'TEST_HOST',
+            'name': 'TEST_NAME',
+            'discover_port': 1111,
+            'token': None
+        }
+
+        self.restservice = ReducerRestService(self.config, mock_control, None)
+
+    def test_check_compute_package(self):
+
+        self.restservice.control.get_compute_context.return_value = {'NOT': 'NONE'}
+        retval = self.restservice.check_compute_context()
+        self.assertTrue(retval)
+
+        self.restservice.control.get_compute_context.return_value = None
+        retval = self.restservice.check_compute_context()
+        self.assertFalse(retval)
+
+        self.restservice.control.get_compute_context.return_value = ''
+        retval = self.restservice.check_compute_context()
+        self.assertFalse(retval)
+
+    def test_check_initial_model(self):
+
+        self.restservice.control.get_latest_model.return_value = 'model-uid'
+        retval = self.restservice.check_initial_model()
+        self.assertTrue(retval)
+
+        self.restservice.control.get_latest_model.return_value = None
+        retval = self.restservice.check_initial_model()
+        self.assertFalse(retval)
+
+        self.restservice.control.get_latest_model.return_value = ''
+        retval = self.restservice.check_initial_model()
+        self.assertFalse(retval)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] Draft
- [ ] Hold

## Description
- Fixes issue that client can still get assigned though no compute package or seed model has been configured.
  "checkers" functions are introduced which check the compute package and seed model in REST /assign. 
- these functions are now also used when "redirecting" URLs to /setup and /setup_model when not configured.

- Introduces new a feature --remote for reducer, enabling only local compute package when --remote is used for client.
  I.e no UI for uploading compute package is needed in this mode/setting. However, the compute package must be "mounted" on each local client. 
- Various other fixes and features (CLI)  associated to the above. 
- Unittests for the newly implemented functions. 

Note: 
control.state in statestore is not used...?

## Types of changes

What types of changes does your code introduce to FEDn?

- [ ] Hotfix (fixing a critical bug in production)
- [x] Bugfix
- [x] New feature
- [ ] Documentation update

## Checklist

_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code._

- [x] This pull request is against **develop** branch (not applicable for hotfixes)
- [ ] I have included a link to the issue on GitHub or JIRA (if any)
- [ ] I have included migration files (if there are changes to the model classes)
- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- [ ] I have included tests to complement my changes
- [ ] I have updated the related documentation (if necessary) 
- [ ] I have added a reviewer for this pull request
- [ ] I have added myself as an author for this pull request

## Further comments

Anything else you think we should know before merging your code!
