### PR TITLE
Simplify PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,37 +1,19 @@
-## Status
-
-- [ ] Ready
-- [ ] Draft
-- [ ] Hold
-
 ## Description
-
+<!-- 
 Describe your changes here to communicate to the maintainers why we should accept this pull request. 
 If it fixes a bug or resolves a feature request, be sure to include a link to that issue.
+-->
 
-## Types of changes
+<!--
+Checklist
+---------
+If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
+This is simply a reminder of what we are going to look for before merging your code.
 
-What types of changes does your code introduce to FEDn?
-
-- [ ] Hotfix (fixing a critical bug in production)
-- [ ] Bugfix
-- [ ] New feature
-- [ ] Refactoring
-- [ ] Documentation update
-
-## Checklist
-
-_If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
-This is simply a reminder of what we are going to look for before merging your code._
-
-- [ ] This pull request is against **develop** branch (not applicable for hotfixes)
-- [ ] I have included a link to the issue on GitHub or JIRA (if any)
-- [ ] I have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
-- [ ] I have included tests to complement my changes
-- [ ] I have updated the related documentation (if necessary) 
-- [ ] I have added a reviewer for this pull request
-- [ ] I have added myself as an author for this pull request
-
-## Further comments
-
-Anything else you think we should know before merging your code!
+- This PR is against **develop** branch (not applicable for hotfixes)
+- You have included a link to the issue on GitHub or JIRA (if any)
+- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
+- You have included tests to complement my changes
+- You have updated the related documentation (if necessary) 
+- You have added a reviewer for this pull request
+-->


### PR DESCRIPTION
## Description
This is a proposal for simplifying the PR template. I have commented out the checklist and the instruction so they will appear as a reminder. Further, I have created a `draft` label that we can use to mark draft PRs. Let me know what you think.
