### PR TITLE
Gramine compatibility patch

### DIFF
--- a/fedn/fedn/common/control/package.py
+++ b/fedn/fedn/common/control/package.py
@@ -215,7 +215,7 @@ class PackageRuntime:
         from_path = os.path.join(os.getcwd(), 'client')
         
         from distutils.dir_util import copy_tree
-        copy_tree(from_path, run_path)
+        copy_tree(from_path, run_path, preserve_times=False)
 
         try:
             cfg = None

--- a/fedn/fedn/common/control/package.py
+++ b/fedn/fedn/common/control/package.py
@@ -215,7 +215,7 @@ class PackageRuntime:
         from_path = os.path.join(os.getcwd(), 'client')
         
         from distutils.dir_util import copy_tree
-        copy_tree(from_path, run_path, preserve_times=False)
+        copy_tree(from_path, run_path, preserve_times=False) # preserve_times=False ensures compatibility with Gramine LibOS
 
         try:
             cfg = None


### PR DESCRIPTION
## Description
This patch enables client compatibility with Gramine. The `preserve_times` flag set to false avoids calling the unimplemented `utime` system call in the LibOS. It doesn't seem like preserving times when copying the files from the package is crucial for FEDn, but please feel free to propose another solution. 

<!-- 
Describe your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to include a link to that issue.
-->

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->