### PR TITLE
Make all links static in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,14 +62,14 @@ Distributed deployment
 
 We provide instructions for a distributed reference deployment here:
 `Distributed
-deployment <https://scaleoutsystems.github.io/fedn/#/deployment>`__.
+deployment <https://scaleoutsystems.github.io/fedn/deployment.html>`__.
 
 Where to go from here
 =====================
 
 -  `Explore additional examples <https://github.com/scaleoutsystems/fedn/tree/master/examples>`__
 -  `Understand the
-   architecture <https://scaleoutsystems.github.io/fedn/#/architecture>`__
+   architecture <https://scaleoutsystems.github.io/fedn/architecture.html>`__
 -  `Understand the compute
    package <https://scaleoutsystems.github.io/fedn/tutorial.html>`__
 

--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ Quick start
 -----------
 
 The quickest way to get started with FEDn is by trying out the `MNIST
-Keras example <examples/mnist-keras>`__. Alternatively, you can start the
+Keras example <https://github.com/scaleoutsystems/fedn/tree/master/examples/mnist-keras>`__. Alternatively, you can start the
 base services along with combiner and reducer as it follows.
 
 .. code-block::
@@ -67,7 +67,7 @@ deployment <https://scaleoutsystems.github.io/fedn/#/deployment>`__.
 Where to go from here
 =====================
 
--  `Explore additional examples <examples>`__
+-  `Explore additional examples <https://github.com/scaleoutsystems/fedn/tree/master/examples>`__
 -  `Understand the
    architecture <https://scaleoutsystems.github.io/fedn/#/architecture>`__
 -  `Understand the compute


### PR DESCRIPTION
## Description
This PR makes all links in the README.rst statics. This is needed as we use the same RST files in both the documentation and the GitHub root README.

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->