### PR TITLE
Make container name in CI logs generic.

### DIFF
--- a/.ci/tests/examples/print_logs.sh
+++ b/.ci/tests/examples/print_logs.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 echo "Minio logs"
-docker logs fedn_minio_1
+docker logs ${PWD}_minio_1
 
 echo "Mongo logs"
-docker logs fedn_mongo_1
+docker logs ${PWD}_mongo_1
 
 echo "Reducer logs"
-docker logs fedn_reducer_1
+docker logs ${PWD}_reducer_1
 
 echo "Combiner logs"
-docker logs fedn_combiner_1
+docker logs ${PWD}_combiner_1
           
 echo "Client 1 logs"
-docker logs fedn_client_1
+docker logs ${PWD}_client_1
 
 echo "Client 2 logs"
-docker logs fedn_client_2
+docker logs ${PWD}_client_2

--- a/.ci/tests/examples/print_logs.sh
+++ b/.ci/tests/examples/print_logs.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 echo "Minio logs"
-docker logs ${PWD}_minio_1
+docker logs ${PWD#*/}_minio_1
 
 echo "Mongo logs"
-docker logs ${PWD}_mongo_1
+docker logs ${PWD#*/}_mongo_1
 
 echo "Reducer logs"
-docker logs ${PWD}_reducer_1
+docker logs ${PWD#*/}_reducer_1
 
 echo "Combiner logs"
-docker logs ${PWD}_combiner_1
+docker logs ${PWD#*/}_combiner_1
           
 echo "Client 1 logs"
-docker logs ${PWD}_client_1
+docker logs ${PWD#*/}_client_1
 
 echo "Client 2 logs"
-docker logs ${PWD}_client_2
+docker logs ${PWD#*/}_client_2

--- a/.ci/tests/examples/print_logs.sh
+++ b/.ci/tests/examples/print_logs.sh
@@ -1,18 +1,18 @@
 #!/bin/bash
 echo "Minio logs"
-docker logs ${PWD#*/}_minio_1
+docker logs "$(basename $PWD)_minio_1"
 
 echo "Mongo logs"
-docker logs ${PWD#*/}_mongo_1
+docker logs "$(basename $PWD)_mongo_1"
 
 echo "Reducer logs"
-docker logs ${PWD#*/}_reducer_1
+docker logs "$(basename $PWD)_reducer_1"
 
 echo "Combiner logs"
-docker logs ${PWD#*/}_combiner_1
+docker logs "$(basename $PWD)_combiner_1"
           
 echo "Client 1 logs"
-docker logs ${PWD#*/}_client_1
+docker logs "$(basename $PWD)_client_1"
 
 echo "Client 2 logs"
-docker logs ${PWD#*/}_client_2
+docker logs "$(basename $PWD)_client_2"


### PR DESCRIPTION
## Description
Make container name in CI logs generic. Important for "private forks".