### PR TITLE
Feature/SK-229 Add docker meta data, fix url

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/scaleoutsystems/fedn/fedn
+            docker.pkg.github.com/${{ github.repository }}/fedn
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -41,7 +41,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/scaleoutsystems/fedn/fedn
+            docker.pkg.github.com/${{ github.repository }}/fedn
           tags: |
             type=ref,event=branch,suffix=-mnist-keras
             type=ref,event=pr,suffix=-mnist-keras
@@ -54,7 +54,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/scaleoutsystems/fedn/fedn
+            docker.pkg.github.com/${{ github.repository }}/fedn
           tags: |
             type=ref,event=branch,suffix=-mnist-pytorch
             type=ref,event=pr,suffix=-mnist-pytorch

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -23,15 +23,45 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Setup variables
-        id: wf-vars
-        env:
-          BASE_BRANCH: ${{ github.base_ref }}
-        run: |
-          IMAGE_TAG=${GITHUB_REF##*/}
-          echo "BASE_BRANCH=${BASE_BRANCH}"
-          echo "IMAGE_TAG=${IMAGE_TAG}"
-          echo ::set-output name=IMAGE_TAG::$IMAGE_TAG
+      - name: Docker meta fedn
+        id: meta1
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/scaleoutsystems/fedn/fedn
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha
+      
+      - name: Docker meta mnist-keras
+        id: meta2
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/scaleoutsystems/fedn/fedn
+          tags: |
+            type=ref,event=branch,suffix=-mnist-keras
+            type=ref,event=pr,suffix=-mnist-keras
+            type=semver,pattern={{version}},suffix=-mnist-keras
+            type=semver,pattern={{major}}.{{minor}},suffix=-mnist-keras
+            type=sha,suffix=-mnist-keras
+      
+      - name: Docker meta mnist-pytorch
+        id: meta3
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ghcr.io/scaleoutsystems/fedn/fedn
+          tags: |
+            type=ref,event=branch,suffix=-mnist-pytorch
+            type=ref,event=pr,suffix=-mnist-pytorch
+            type=semver,pattern={{version}},suffix=-mnist-pytorch
+            type=semver,pattern={{major}}.{{minor}},suffix=-mnist-pytorch
+            type=sha,suffix=-mnist-pytorch
+
 
       - name: Log in to GitHub Docker Registry
         uses: docker/login-action@v1
@@ -44,14 +74,16 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: "${{ github.event_name != 'pull_request' }}"
-          tags: docker.pkg.github.com/${{ github.repository }}/fedn:${{ steps.wf-vars.outputs.IMAGE_TAG }}
+          tags: ${{ steps.meta1.outputs.tags }}
+          labels: ${{ steps.meta1.outputs.labels }}
           file: Dockerfile
 
       - name: Build and push (mnist-keras)
         uses: docker/build-push-action@v2
         with:
           push: "${{ github.event_name != 'pull_request' }}"
-          tags: docker.pkg.github.com/${{ github.repository }}/fedn:${{ steps.wf-vars.outputs.IMAGE_TAG }}-mnist-keras
+          tags: ${{ steps.meta2.outputs.tags }}
+          labels: ${{ steps.meta2.outputs.labels }}
           file: Dockerfile
           build-args: |
             REQUIREMENTS=examples/mnist-keras/requirements.txt
@@ -60,7 +92,8 @@ jobs:
         uses: docker/build-push-action@v2
         with:
           push: "${{ github.event_name != 'pull_request' }}"
-          tags: docker.pkg.github.com/${{ github.repository }}/fedn:${{ steps.wf-vars.outputs.IMAGE_TAG }}-mnist-pytorch
+          tags: ${{ steps.meta3.outputs.tags }}
+          labels: ${{ steps.meta3.outputs.labels }}
           file: Dockerfile
           build-args: |
             REQUIREMENTS=examples/mnist-pytorch/requirements.txt


### PR DESCRIPTION
## Description
<!-- 
Issue with container registry for new docker meta data github.actor using secrets.GITHUB_TOKEN unauthorized. Possible cause might be that we changed from docker.pkg.github.com to ghcr.io. 
-->

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->