### PR TITLE
change to old container registry url

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/scaleoutsystems/fedn/fedn
+            docker.pkg.github.com/${{ github.repository }}/fedn
           tags: |
             type=ref,event=branch
             type=ref,event=pr
@@ -41,7 +41,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/scaleoutsystems/fedn/fedn
+            docker.pkg.github.com/${{ github.repository }}/fedn
           tags: |
             type=ref,event=branch,suffix=-mnist-keras
             type=ref,event=pr,suffix=-mnist-keras
@@ -54,7 +54,7 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: |
-            ghcr.io/scaleoutsystems/fedn/fedn
+            docker.pkg.github.com/${{ github.repository }}/fedn
           tags: |
             type=ref,event=branch,suffix=-mnist-pytorch
             type=ref,event=pr,suffix=-mnist-pytorch


### PR DESCRIPTION
## Description
<!-- 
Issue unauthorized to push to container registry based on github.actor and secrets.GITHUB_TOKEN. Related to #427. Try to change ghcr url. 
-->

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->