### PR TITLE
Feature/SK-248 Enable CA signed cert for GRPC channel

### DIFF
--- a/fedn/fedn/client.py
+++ b/fedn/fedn/client.py
@@ -264,6 +264,12 @@ class Client:
             with open(os.environ["FEDN_GRPC_ROOT_CERT_PATH"], 'rb') as f:
                 credentials = grpc.ssl_channel_credentials(f.read())
             channel = grpc.secure_channel("{}:{}".format(host, str(port)), credentials)
+        elif self.config['secure']:
+            secure = True
+            print("CLIENT: using CA certificate for GRPC channel")
+
+            credentials = grpc.ssl_channel_credentials()
+            channel = grpc.secure_channel("{}:{}".format(host, str(port)), credentials)
         else:
             print("CLIENT: using insecure GRPC channel")
             channel = grpc.insecure_channel("{}:{}".format(


### PR DESCRIPTION
## Description
It should not be necessary to provide with cert to grpc client if it's a CA signed cert. This PR fixes that.

<!-- 
Describe your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to include a link to that issue.
-->

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->