### PR TITLE
Bugfix - Fetch ca cert via ssl package 

### DIFF
--- a/fedn/fedn/client.py
+++ b/fedn/fedn/client.py
@@ -9,6 +9,7 @@ import tempfile
 import threading
 import time
 import uuid
+import ssl
 from datetime import datetime
 from distutils.dir_util import copy_tree
 from io import BytesIO
@@ -267,8 +268,9 @@ class Client:
         elif self.config['secure']:
             secure = True
             print("CLIENT: using CA certificate for GRPC channel")
+            cert = ssl.get_server_certificate((host, port))
 
-            credentials = grpc.ssl_channel_credentials()
+            credentials = grpc.ssl_channel_credentials(cert.encode('utf-8'))
             channel = grpc.secure_channel("{}:{}".format(host, str(port)), credentials)
         else:
             print("CLIENT: using insecure GRPC channel")

--- a/fedn/fedn/client.py
+++ b/fedn/fedn/client.py
@@ -4,12 +4,12 @@ import json
 import os
 import queue
 import re
+import ssl
 import sys
 import tempfile
 import threading
 import time
 import uuid
-import ssl
 from datetime import datetime
 from distutils.dir_util import copy_tree
 from io import BytesIO


### PR DESCRIPTION
## Description
For some reason grpc credentials can't verify Let's Encrypt cert, might be due to outdated trusted CA/root.pem. When using python package ssl instead, it works. 
<!-- 
Describe your changes here to communicate to the maintainers why we should accept this pull request. 
If it fixes a bug or resolves a feature request, be sure to include a link to that issue.
-->

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->