### PR TITLE
Feature/438

### DIFF
--- a/config/settings-client.yaml.template
+++ b/config/settings-client.yaml.template
@@ -1,4 +1,3 @@
 network_id: fedn-test-network
-controller:
-    discover_host: reducer
-    discover_port: 8090
+discover_host: reducer
+discover_port: 8090

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -39,6 +39,30 @@ def check_helper_config_file(config):
     return helper
 
 
+def parse_client_config(config):
+    """Parse client config from file.
+
+    Override configs from the CLI with settings in config file.
+
+    :param config: Client config dict.
+    """
+    with open(config['init'], 'r') as file:
+        try:
+            settings = dict(yaml.safe_load(file))
+        except Exception:
+            print('Failed to read config from settings file, exiting.', flush=True)
+            return
+
+    # Read/overide settings from config file
+    if 'controller' in settings:
+        reducer_config = settings['controller']
+        for key, val in reducer_config.items():
+            config[key] = val
+
+    if 'name' in settings:
+        config['name'] = settings['name']
+
+
 @main.group('run')
 @click.pass_context
 def run_cmd(ctx):
@@ -102,21 +126,10 @@ def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, local_pa
               'validator': validator, 'trainer': trainer, 'init': init, 'logfile': logfile, 'heartbeat_interval': heartbeat_interval,
               'reconnect_after_missed_heartbeat': reconnect_after_missed_heartbeat}
 
-    if config['init']:
-        with open(config['init'], 'r') as file:
-            try:
-                settings = dict(yaml.safe_load(file))
-            except Exception:
-                print('Failed to read config from settings file, exiting.', flush=True)
-                return
-                # raise(e)
+    if init:
+        parse_client_config(config)
 
-        # Read/overide settings from config file
-        if 'controller' in settings:
-            reducer_config = settings['controller']
-            for key, val in reducer_config.items():
-                config[key] = val
-
+    # TODO: Refactor into validate_client_config
     try:
         if config['discover_host'] is None or \
                 config['discover_host'] == '':

--- a/fedn/fedn/clients/reducer/restservice.py
+++ b/fedn/fedn/clients/reducer/restservice.py
@@ -846,8 +846,8 @@ class ReducerRestService:
             discover_port = self.port
             ctx = """network_id: {network_id}
 controller:
-    host: {discover_host}
-    port: {discover_port}
+    discover_host: {discover_host}
+    discover_port: {discover_port}
     {chk_string}""".format(network_id=network_id,
                            discover_host=discover_host,
                            discover_port=discover_port,

--- a/fedn/fedn/clients/reducer/restservice.py
+++ b/fedn/fedn/clients/reducer/restservice.py
@@ -845,13 +845,12 @@ class ReducerRestService:
             discover_host = self.name
             discover_port = self.port
             ctx = """network_id: {network_id}
-controller:
-    discover_host: {discover_host}
-    discover_port: {discover_port}
-    {chk_string}""".format(network_id=network_id,
-                           discover_host=discover_host,
-                           discover_port=discover_port,
-                           chk_string=chk_string)
+discover_host: {discover_host}
+discover_port: {discover_port}
+{chk_string}""".format(network_id=network_id,
+                       discover_host=discover_host,
+                       discover_port=discover_port,
+                       chk_string=chk_string)
 
             obj = BytesIO()
             obj.write(ctx.encode('UTF-8'))

--- a/fedn/fedn/common/exceptions.py
+++ b/fedn/fedn/common/exceptions.py
@@ -1,2 +1,6 @@
 class ModelError(BaseException):
     pass
+
+
+class InvalidClientConfig(BaseException):
+    pass


### PR DESCRIPTION
## Description
Enables config of all settings in client.yaml (mirror CLI). 

This is a breaking change, it changes the structure of the client config yaml file (now flat). Example, 

discover_host: r5658787a.studio.scaleoutsystems.com
token: XXXXXXXXXXXXXXXXXXXX
network_id: fedn_test_network
name: andreas-1
secure: True

Prerequisite for SK-251. Resolves #438 

