### PR TITLE
Redis for backend statestore.

### DIFF
--- a/config/reducer-settings.override.yaml
+++ b/config/reducer-settings.override.yaml
@@ -2,8 +2,8 @@
 version: '3.3'
 
 # Overriding settings
-services:
-  reducer:
-    volumes:
-      - ${HOST_REPO_DIR:-.}/fedn:/app/fedn
-      - ${HOST_REPO_DIR:-.}/config/settings-reducer.yaml:/app/config/settings-reducer.yaml
+#services:
+#  reducer:
+#    volumes:
+#      - ${HOST_REPO_DIR:-.}/fedn:/app/fedn
+#      - ${HOST_REPO_DIR:-.}/config/settings-reducer.yaml:/app/config/settings-reducer.yaml

--- a/config/settings-reducer.yaml.template
+++ b/config/settings-reducer.yaml.template
@@ -6,12 +6,11 @@ control:
   helper: keras
 
 statestore:
-  type: MongoDB
-  mongo_config:
-    username: fedn_admin
-    password: password
-    host: mongo
-    port: 6534
+  type: "Redis"
+  redis_config:
+    host: redis
+    port: 6379
+    db: 0
 
 storage:
   storage_type: S3

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,6 +8,15 @@ networks:
 
 services:
   # Base services
+  redis:
+    image: redis:6.2-alpine
+    restart: always
+    ports:
+      - '6379:6379'
+    command: redis-server --save 20 1 --loglevel warning
+    #--requirepass eYVX7EwVmmxKPCDmwMtyKVge8oLd2t81
+    #volumes:
+    #  - redis:/data
   minio:
     image: minio/minio:14128-5ee91dc
     hostname: minio
@@ -33,30 +42,30 @@ services:
       - 9000:9000
       - 9001:9001
 
-  mongo:
-    image: mongo:5.0.2
-    restart: always
-    environment:
-      - MONGO_INITDB_ROOT_USERNAME=fedn_admin
-      - MONGO_INITDB_ROOT_PASSWORD=password
-    ports:
-      - 6534:6534
-    command: mongod --port 6534
+  #mongo:
+  #  image: mongo:5.0.2
+  #  restart: always
+  #  environment:
+  #    - MONGO_INITDB_ROOT_USERNAME=fedn_admin
+  #    - MONGO_INITDB_ROOT_PASSWORD=password
+  #  ports:
+  #    - 6534:6534
+  #  command: mongod --port 6534
 
-  mongo-express:
-    image: mongo-express:latest
-    restart: always
-    depends_on:
-      - "mongo"
-    environment:
-      - ME_CONFIG_MONGODB_SERVER=mongo
-      - ME_CONFIG_MONGODB_PORT=6534
-      - ME_CONFIG_MONGODB_ADMINUSERNAME=fedn_admin
-      - ME_CONFIG_MONGODB_ADMINPASSWORD=password
-      - ME_CONFIG_BASICAUTH_USERNAME=fedn_admin
-      - ME_CONFIG_BASICAUTH_PASSWORD=password
-    ports:
-      - 8081:8081
+  #mongo-express:
+  #  image: mongo-express:latest
+  #  restart: always
+  #  depends_on:
+  #    - "mongo"
+  #  environment:
+  #    - ME_CONFIG_MONGODB_SERVER=mongo
+  #    - ME_CONFIG_MONGODB_PORT=6534
+  #    - ME_CONFIG_MONGODB_ADMINUSERNAME=fedn_admin
+  #    - ME_CONFIG_MONGODB_ADMINPASSWORD=password
+  #    - ME_CONFIG_BASICAUTH_USERNAME=fedn_admin
+  #    - ME_CONFIG_BASICAUTH_PASSWORD=password
+  #  ports:
+  #    - 8081:8081
 
   # Reducer
   reducer:
@@ -72,10 +81,10 @@ services:
         BASE_IMG: ${BASE_IMG:-python:3.9-slim}
     working_dir: /app
     volumes:
-      - ${HOST_REPO_DIR:-.}/fedn:/app/fedn
+      - ./fedn:/app/fedn
     entrypoint: [ "sh", "-c" ]
     command:
-      - "/venv/bin/pip install --no-cache-dir -e /app/fedn && /venv/bin/fedn run reducer -n reducer --init=config/settings-reducer.yaml"
+      - "/venv/bin/pip install --no-cache-dir -e /app/fedn && /venv/bin/fedn run reducer -n reducer --init=/app/config/settings-reducer.yaml"
     ports:
       - 8090:8090
 
@@ -90,7 +99,7 @@ services:
         BASE_IMG: ${BASE_IMG:-python:3.9-slim}
     working_dir: /app
     volumes:
-      - ${HOST_REPO_DIR:-.}/fedn:/app/fedn
+      - ./fedn:/app/fedn
     entrypoint: [ "sh", "-c" ]
     command:
       - "/venv/bin/pip install --no-cache-dir -e /app/fedn && /venv/bin/fedn run combiner -in config/settings-combiner.yaml"
@@ -105,11 +114,19 @@ services:
       context: .
       args:
         BASE_IMG: ${BASE_IMG:-python:3.9-slim}
+        #REQUIREMENTS: examples/mnist-keras/requirements.txt
+        #REQUIREMENTS: requirements-client.txt
     working_dir: /app
     volumes:
-      - ${HOST_REPO_DIR:-.}/fedn:/app/fedn
+      - ./fedn:/app/fedn
+      - ./examples/mnist-pytorch:/app/examples/mnist-pytorch
+    #  - ./examples/mnist-keras/data:/var/data
     entrypoint: [ "sh", "-c" ]
     command:
-      - "/venv/bin/pip install --no-cache-dir -e /app/fedn && /venv/bin/fedn run client -in config/settings-client.yaml"
+      - "sleep 20 && /venv/bin/pip install --no-cache-dir -e /app/fedn && /venv/bin/fedn run client -in config/settings-client.yaml"
     deploy:
       replicas: 0
+
+#volumes:
+#  redis:
+#    driver: local

--- a/examples/mnist-keras/bin/init_venv.sh
+++ b/examples/mnist-keras/bin/init_venv.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 set -e
 
+apt-get install gcc python3-dev
 # Init venv
 python -m venv .mnist-keras
 
 # Pip deps
 .mnist-keras/bin/pip install --upgrade pip
-.mnist-keras/bin/pip install -e ../../fedn
+.mnist-keras/bin/pip install -e fedn
 .mnist-keras/bin/pip install -r requirements.txt

--- a/examples/mnist-keras/client/entrypoint
+++ b/examples/mnist-keras/client/entrypoint
@@ -1,4 +1,4 @@
-#!./.mnist-keras/bin/python
+#!/Users/morgan/develop/scaleout/fedn/env/bin/python3
 import json
 import os
 

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -7,8 +7,7 @@ import yaml
 from fedn.client import Client
 from fedn.clients.reducer.restservice import (decode_auth_token,
                                               encode_auth_token)
-from fedn.clients.reducer.statestore.mongoreducerstatestore import \
-    MongoReducerStateStore
+
 from fedn.combiner import Combiner
 from fedn.common.exceptions import InvalidClientConfig
 from fedn.reducer import Reducer
@@ -188,9 +187,19 @@ def reducer_cmd(ctx, host, port, secret_key, local_package, name, init):
 
     # Obtain state from database, in case already initialized (service restart)
     statestore_config = fedn_config['statestore']
-    if statestore_config['type'] == 'MongoDB':
-        statestore = MongoReducerStateStore(
-            network_id, statestore_config['mongo_config'], defaults=config['init'])
+    #if statestore_config['type'] == 'MongoDB':
+    #    from fedn.clients.reducer.statestore.mongoreducerstatestore import \
+    #        MongoReducerStateStore
+    #    statestore = MongoReducerStateStore(
+    #        network_id, statestore_config['mongo_config'], defaults=config['init'])
+    # elif statestore_config['type'] == 'Redis':
+    print("the statestore_config is: ", statestore_config, flush=True)
+    if statestore_config['type'].lower() == 'redis':
+
+        from fedn.clients.reducer.statestore.redisreducerstatestore import \
+            RedisReducerStateStore
+        statestore = RedisReducerStateStore(
+            network_id, statestore_config['redis_config'], defaults=config['init'])
     else:
         print("Unsupported statestore type, exiting. ", flush=True)
         exit(-1)

--- a/fedn/fedn/clients/combiner/roundcontrol.py
+++ b/fedn/fedn/clients/combiner/roundcontrol.py
@@ -302,7 +302,7 @@ class RoundControl:
                             round_meta['time_exec_training'] = time.time() - \
                                 tic
                             round_meta['name'] = self.id
-                            self.server.tracer.set_round_meta(round_meta)
+                            #self.server.tracer.set_round_meta(round_meta)
                         elif round_config['task'] == 'validation':
                             self.execute_validation(round_config)
                         else:

--- a/fedn/fedn/clients/reducer/endpoints/dashboard.py
+++ b/fedn/fedn/clients/reducer/endpoints/dashboard.py
@@ -1,0 +1,31 @@
+
+@app.route('/dashboard')
+def dashboard():
+    """
+
+    :return:
+    """
+    # Token auth
+    if self.token_auth_enabled:
+        self.authorize(request, app.config.get('SECRET_KEY'))
+
+    not_configured = self.check_configured()
+    if not_configured:
+        return not_configured
+
+    plot = Plot(self.control.statestore)
+    combiners_plot = plot.create_combiner_plot()
+
+    timeline_plot = None
+    table_plot = None
+    clients_plot = plot.create_client_plot()
+    client_histogram_plot = plot.create_client_histogram_plot()
+
+    return render_template('dashboard.html', show_plot=True,
+                           table_plot=table_plot,
+                           timeline_plot=timeline_plot,
+                           clients_plot=clients_plot,
+                           client_histogram_plot=client_histogram_plot,
+                           combiners_plot=combiners_plot,
+                           configured=True
+                           )

--- a/fedn/fedn/clients/reducer/endpoints/metric.py
+++ b/fedn/fedn/clients/reducer/endpoints/metric.py
@@ -1,0 +1,10 @@
+@app.route('/metric_type', methods=['GET', 'POST'])
+def change_features():
+    """
+
+    :return:
+    """
+    feature = request.args['selected']
+    plot = Plot(self.control.statestore)
+    graphJSON = plot.create_box_plot(feature)
+    return graphJSON

--- a/fedn/fedn/clients/reducer/endpoints/network.py
+++ b/fedn/fedn/clients/reducer/endpoints/network.py
@@ -1,0 +1,42 @@
+@app.route('/networkgraph')
+        def network_graph():
+
+            try:
+                plot = Plot(self.control.statestore)
+                result = netgraph()
+                df_nodes = pd.DataFrame(result['nodes'])
+                df_edges = pd.DataFrame(result['edges'])
+                graph = plot.make_netgraph_plot(df_edges, df_nodes)
+                return json.dumps(json_item(graph, "myplot"))
+            except Exception:
+                raise
+                # return ''
+
+
+@app.route('/network')
+        def network():
+            """
+
+            :return:
+            """
+            # Token auth
+            if self.token_auth_enabled:
+                self.authorize(request, app.config.get('SECRET_KEY'))
+
+            not_configured = self.check_configured()
+            if not_configured:
+                return not_configured
+            plot = Plot(self.control.statestore)
+            round_time_plot = plot.create_round_plot()
+            mem_cpu_plot = plot.create_cpu_plot()
+            combiner_info = combiner_status()
+            active_clients = client_status()
+            return render_template('network.html', network_plot=True,
+                                   round_time_plot=round_time_plot,
+                                   mem_cpu_plot=mem_cpu_plot,
+                                   combiner_info=combiner_info,
+                                   active_clients=active_clients['active_clients'],
+                                   active_trainers=active_clients['active_trainers'],
+                                   active_validators=active_clients['active_validators'],
+                                   configured=True
+                                   )

--- a/fedn/fedn/clients/reducer/plots.py
+++ b/fedn/fedn/clients/reducer/plots.py
@@ -13,16 +13,16 @@ from bokeh.plotting import figure, from_networkx
 from networkx.algorithms import community
 from plotly.subplots import make_subplots
 
-from fedn.common.storage.db.mongo import connect_to_mongodb
+#from fedn.common.storage.db.mongo import connect_to_mongodb
 
-
+"""
 class Plot:
-    """
-
-    """
-
+   
     def __init__(self, statestore):
+        raise Exception("This class need to be decoupled from direct use of mongoDB.")
+
         try:
+
             statestore_config = statestore.get_config()
             self.mdb = connect_to_mongodb(
                 statestore_config['mongo_config'], statestore_config['network_id'])
@@ -669,3 +669,4 @@ class Plot:
         plot.grid.visible = False
         plot.outline_line_color = None
         return plot
+"""

--- a/fedn/fedn/clients/reducer/statestore/mongoreducerstatestore.py
+++ b/fedn/fedn/clients/reducer/statestore/mongoreducerstatestore.py
@@ -6,6 +6,7 @@ import yaml
 
 from fedn.clients.reducer.state import (ReducerStateToString,
                                         StringToReducerState)
+
 from fedn.common.storage.db.mongo import connect_to_mongodb
 
 from .reducerstatestore import ReducerStateStore
@@ -112,17 +113,17 @@ class MongoReducerStateStore(ReducerStateStore):
         """
         return self.__inited
 
-    def get_config(self):
-        """
+    #def get_config(self):
+    #    """
 
-        :return:
-        """
-        data = {
-            'type': 'MongoDB',
-            'mongo_config': self.config,
-            'network_id': self.network_id
-        }
-        return data
+    #    :return:
+    #    """
+    #    data = {
+    #        'type': 'MongoDB',
+    #        'mongo_config': self.config,
+    #        'network_id': self.network_id
+    #    }
+    #    return data
 
     def state(self):
         """

--- a/fedn/fedn/clients/reducer/statestore/postgresstatestore.py
+++ b/fedn/fedn/clients/reducer/statestore/postgresstatestore.py
@@ -1,0 +1,89 @@
+import confuse
+
+def get_config(model,value):
+    import SQLAlchemy
+
+
+
+from reducerstatestore import ReducerStateStore
+class PostgressStateStore(ReducerStateStore):
+
+    @classmethod
+    def load_from_file(cls, defaults):
+        """
+        Load configuration from file.
+        """
+        config = confuse.Configuration('FEDn_Reducer', __name__)
+        config.set_file(defaults)
+
+        cls.state = config['control']['state'].get()
+        try:
+            cls.transition(cls.state)
+        except KeyError:
+            cls.transition("idle")
+
+        try:
+            cls.model = config['control']['model'].get()
+        except Exception as e:
+            pass
+        cls.round = config['control']['round'].get()
+
+        cls.round_config = {'timeout': 180, 'validate': True}
+        try:
+            cls.round_config = config['control']['round_config'].get()
+        except:
+            pass
+        cls.set_storage_backend(config['storage'].get())
+        #return config
+        return True
+
+    def __init__(self, network_id, config, defaults=None):
+        self.__inited = False
+
+        if defaults:
+            if ReducerStateStore.load_from_file(self, defaults):
+                if self.write_config_to_statestore():
+                    self.__inited = True
+
+        if not self.__inited:
+            self.reducer = get_config('network','reducer')
+            self.combiners = get_config('network','combiners')
+            self.clients = get_config('network','clients')
+            self.storage = get_config('network','storage')
+            self.certificates = get_config('network','certificates')
+
+            self.control_config = get_config('control','config')
+            self.state = get_config('control','state')
+            self.model = get_config('control','model')
+            self.round = get_config('control','round')
+
+            self.status = get_config('control','status')
+            self.round_time = get_config('control','round_time')
+            self.psutil_monitoring = get_config('control','psutil_monitoring')
+            self.combiner_round_time = get_config('control','combiner_round_time')
+
+        self.__inited = True
+
+        """Mongo Configuration 
+        # FEDn network
+        self.network = self.mdb['network']
+            self.reducer = self.network['reducer']
+            self.combiners = self.network['combiners']
+            self.clients = self.network['clients']
+            self.storage = self.network['storage']
+            self.certificates = self.network['certificates']
+        # Control
+        self.control = self.mdb['control']
+            self.control_config = self.control['config']
+            self.state = self.control['state']
+            self.model = self.control['model']
+            self.round = self.control["round"]
+
+        # Logging and dashboards
+            self.status = self.control["status"]
+            self.round_time = self.control["round_time"]
+            self.psutil_monitoring = self.control["psutil_monitoring"]
+            self.combiner_round_time = self.control['combiner_round_time']
+
+        self.__inited = True
+        """

--- a/fedn/fedn/clients/reducer/statestore/redisreducerstatestore.py
+++ b/fedn/fedn/clients/reducer/statestore/redisreducerstatestore.py
@@ -1,0 +1,540 @@
+from .reducerstatestore import ReducerStateStore
+from fedn.clients.reducer.state import (ReducerStateToString,
+                                        StringToReducerState)
+import redis
+
+import pickle
+r = redis.Redis(host='redis', port=6379, db=0)
+def get_config(namespace,name, default_value=None):
+    #if isinstance(value, dict):
+    #    value = r.hgetall("fedn:config:{}:{}".format(namespace, name))
+    #else:
+    #    value = r.get("fedn:config:{}:{}".format(namespace, name))
+    value = None
+    try:
+        temp = r.get("fedn:config:{}:{}".format(namespace, name))
+        value = pickle.loads(temp)
+        if value is None:
+            return default_value
+    except Exception as e:
+        print("error no value for {}:{}".format(namespace,name), e, flush=True)
+        return None
+    return value
+
+def set_config(namespace,name,value):
+    status = None
+
+    print("setting config for {}:{} and value {}".format(namespace, name, value), flush=True)
+    if value is None:
+        print("value is none ,why set to none?? for {}:{}".format(namespace, name), flush=True)
+        return None
+    try:
+        p_value = pickle.dumps(value)
+        status = r.set("fedn:config:{}:{}".format(namespace, name), p_value)
+        #if isinstance(value, dict):
+        #    status = r.hmset("fedn:config:{}:{}".format(namespace, name), value)
+        #else:
+        #    status = r.set("fedn:config:{}:{}".format(namespace, name), value)
+    except Exception as e:
+        print("Error:", e, flush=True)
+
+    return status
+
+def push_log(namespace, name, value):
+    p_val = pickle.dumps(value)
+    r.rpush("fedn:log:{}:{}".format(namespace, name), p_val)
+
+def set_log(namespace, name, values):
+    for i in range(0, r.llen("fedn:config:{}:{}".format(namespace, name))):
+        r.lpop("fedn:config:{}:{}".format(namespace, name))
+    for v in values:
+        p_v = pickle.dumps(v)
+        r.rpush("fedn:log:{}:{}".format(namespace, name), p_v)
+
+def get_log(namespace, name):
+    vals = r.lrange("fedn:log:{}:{}".format(namespace, name), 0, -1)
+    return [pickle.loads(v) for v in vals]
+
+def get_log_len(namespace, name):
+    return r.llen("fedn:log:{}:{}".format(namespace, name))
+class RedisReducerStateStore(ReducerStateStore):
+    def __init__(self, network_id, config, defaults=None):
+        self.__inited = False
+        self.network_id = network_id
+        #TODO move in the redis instantiation to a class varialbe and make the config from config dict.
+
+
+        if not self.__inited:
+            self.reducer = get_config('network','reducer')
+            self.combiners = get_config('network','combiners')
+            self.clients = get_config('network','clients')
+            self.storage = get_config('network','storage')
+            self.certificates = get_config('network','certificates')
+
+            self.control_config = get_config('control','config')
+            self.state = get_config('control','state')
+            self.model = get_config('control','model')
+            self.round = get_config('control','round')
+
+            #self.status = get_config('control','status')
+            self.round_time = get_config('control','round_time')
+            self.psutil_monitoring = get_config('control','psutil_monitoring')
+            self.combiner_round_time = get_config('control','combiner_round_time')
+
+        self.__inited = True
+
+    def is_inited(self):
+        """
+
+        :return:
+        """
+        return self.__inited
+
+    #def get_config(self):
+
+    #    data = {
+    #       'type': 'Redis',
+    #        'redis_config': self.config,
+    #        'network_id': self.network_id
+    #    }
+    #    return data
+
+    def state(self):
+        """
+
+        :return:
+        """
+        state = get_config('control', 'state')
+        return StringToReducerState(state)
+
+    def transition(self, state):
+        """
+
+        :param state:
+        :return:
+        """
+        old_state = get_config('control', 'state')
+        #old_state = self.state.find_one({'state': 'current_state'})
+        if old_state != state:
+            set_config('control', 'state', ReducerStateToString(state))
+            #return self.state.update_one({'state': 'current_state'}, {'$set': {'state': ReducerStateToString(state)}},
+            #                             True)
+        else:
+            print("Not updating state, already in {}".format(
+                ReducerStateToString(state)))
+
+    def set_latest(self, model_id):
+        """
+
+        :param model_id:
+        """
+        set_config('control', 'model', model_id)
+
+        #self.model.update_one({'key': 'current_model'}, {
+        #    '$set': {'model': model_id}}, True)
+        from datetime import datetime
+        data = { 'model': model_id, 'committed_at': str(datetime.now()) }
+        #set_config('control', 'model', data)
+
+        models = get_config('log', 'model_trail')
+        if models is not None:
+            models.append(data)
+        else:
+            models = [data]
+        set_config('log', 'model_trail', models)
+        #push_log('log','model_trail', data)
+        #self.model.update_one({'key': 'model_trail'},
+        #                      {'$push': {'model': model_id, 'committed_at': str(datetime.now())}},
+        #                      True)
+
+    def get_first(self):
+        """ Return model_id for the latest model in the model_trail """
+        models = get_config('log','model_trail')
+        if models is not None:
+            if len(models) > 0:
+
+                return models[0]
+
+        return None
+        #ret = self.model.find_one({'key': 'model_trail'}, sort=[
+        #    ("committed_at", pymongo.ASCENDING)])
+        #if ret is None:
+        #    return None
+
+        #try:
+        #    model_id = ret['model']
+        #    if model_id == '' or model_id == ' ':  # ugly check for empty string
+        #        return None
+        #    return model_id
+        #except (KeyError, IndexError):
+        #    return None
+
+    def get_latest(self):
+        """ Return model_id for the latest model in the model_trail """
+        return get_config('control', 'model', None)
+        #models = get_config('log','model_trail')
+        #if models is not None:
+        #    if len(models) > 0:
+        #        return models[len(models)-1]
+
+        #ret = self.model.find_one({'key': 'current_model'})
+        #if ret is None:
+        #    return None
+
+        #try:
+        #    model_id = ret['model']
+        #    if model_id == '' or model_id == ' ':  # ugly check for empty string
+        #        return None
+        #    return model_id
+        #except (KeyError, IndexError):
+        #    return None
+        #return None
+
+    def set_round_config(self, config):
+        """
+
+        :param config:
+        """
+        set_config('control', 'round_config', config)
+        #self.control.config.update_one(
+        #    {'key': 'round_config'}, {'$set': config}, True)
+
+    def get_round_config(self):
+        """
+
+        :return:
+        """
+        return get_config('control', 'round_config')
+        #ret = self.control.config.find({'key': 'round_config'})
+        #try:
+        #    retcheck = ret[0]
+        #    if retcheck is None or retcheck == '' or retcheck == ' ':  # ugly check for empty string
+        #        return None
+        #    return retcheck
+        #except (KeyError, IndexError):
+        #    return None
+
+    def set_compute_context(self, filename):
+        """
+
+        :param filename:
+        """
+        from datetime import datetime
+
+        data =  {
+            'filename': filename,
+            'committed_at': str(datetime.now())
+        }
+        set_config('control', 'package', data)
+        #set_config('log','package_trail', data)
+        #self.control.config.update_one(
+        #    {'key': 'package'}, {'$set': {'filename': filename}}, True)
+        #self.control.config.update_one({'key': 'package_trail'},
+        #                               {'$push': {'filename': filename, 'committed_at': str(datetime.now())}}, True)
+
+    def get_compute_context(self):
+        """
+
+        :return:
+        """
+        return get_config('control', 'package')
+        #ret = self.control.config.find({'key': 'package'})
+        #try:
+        #    retcheck = ret[0]
+        #    if retcheck is None or retcheck == '' or retcheck == ' ':  # ugly check for empty string
+        #        return None
+        #    return retcheck
+        #except (KeyError, IndexError):
+        #    return None
+
+    def set_framework(self, helper):
+        """
+
+        :param helper:
+        """
+        set_config('control', 'helper', helper)
+        #self.control.config.update_one({'key': 'package'},
+        #                               {'$set': {'helper': helper}}, True)
+
+    def get_framework(self):
+        """
+
+        :return:
+        """
+        return get_config('control', 'helper')
+        #ret = self.control.config.find_one({'key': 'package'})
+        # if local compute package used, then 'package' is None
+        #if not ret:
+        #    # get framework from round_config instead
+        #    ret = self.control.config.find_one({'key': 'round_config'})
+        #print('FRAMEWORK:', ret)
+        #try:
+        #    retcheck = ret['helper']
+        #    if retcheck == '' or retcheck == ' ':  # ugly check for empty string
+        #        return None
+        #    return retcheck
+        #except (KeyError, IndexError):
+        #    return None
+
+    def get_model_info(self):
+        """
+
+        :return:
+        """
+        models = get_config('log','model_trail')
+        return models[len(models)-1]
+
+        #ret = self.model.find_one({'key': 'model_trail'})
+        #try:
+        #    if ret:
+        #        committed_at = ret['committed_at']
+        #        model = ret['model']
+        #        model_dictionary = dict(zip(model, committed_at))
+        #        return model_dictionary
+        #    else:
+        #        return None
+        #except (KeyError, IndexError):
+        #    return None
+
+    #def get_events(self):
+    #    """
+
+    #   :return:
+    #    """
+    #    ret = self.control.status.find({})
+    #    return ret
+
+    def get_storage_backend(self):
+        """  """
+        return get_config('control', 'storage_backend')
+        #try:
+        #    ret = self.storage.find(
+        #        {'status': 'enabled'}, projection={'_id': False})
+        #    return ret[0]
+        #except (KeyError, IndexError):
+        #    return None
+
+    def set_storage_backend(self, config):
+        """ """
+        return set_config('control', 'storage_backend', config)
+        #config = copy.deepcopy(config)
+        #config['updated_at'] = str(datetime.now())
+        #config['status'] = 'enabled'
+        #self.storage.update_one(
+        #    {'storage_type': config['storage_type']}, {'$set': config}, True)
+
+    def set_reducer(self, reducer_data):
+        """ """
+        from datetime import datetime
+        print("set reduce 1", flush=True)
+        reducer_data['updated_at'] = str(datetime.now())
+        print("set reduce 2", flush=True)
+        print("CHECK1: setting config for reducer {}".format(reducer_data), flush=True)
+        set_config('control', 'reducer', reducer_data)
+
+        config = get_config('control', 'reducer')
+        print("CHECK2: got config for reducer {}".format(config), flush=True)
+
+        print("set reduce 3", flush=True)
+        #self.reducer.update_one({'name': reducer_data['name']}, {
+        #    '$set': reducer_data}, True)
+
+    def get_reducer(self):
+        """ """
+        return get_config('control', 'reducer')
+        #try:
+        #    ret = self.reducer.find_one()
+        #    return ret
+        #except Exception:
+        #    return None
+
+    #def list_combiners(self):
+    #    """ """
+    #    return get_log('control', 'combiners')
+        #try:
+        #    ret = self.combiners.find()
+        #    return list(ret)
+        #except Exception:
+        #    return None
+
+    def get_combiner(self, name):
+        """ """
+        combiners = get_config('control', 'combiners')
+        if combiners is None or len(combiners) == 0:
+            print("no combiners found", flush=True)
+            return None
+        for c in combiners:
+            if c['name'] == name:
+                print("found combiner with name {}".format(name), flush=True)
+                return c
+
+        print("no combiner found with name:{}".format(name), flush=True)
+        return None
+        #try:
+        #    ret = self.combiners.find_one({'name': name})
+        #    return ret
+        #except Exception:
+        #    return None
+
+    def get_combiners(self):
+        val = get_config('control', 'combiners')
+        if val is None:
+            return []
+        return val
+
+        #try:
+        #    ret = self.combiners.find()
+        #    return list(ret)
+        #except Exception:
+        #    return None
+
+    def set_combiner(self, combiner_data):
+        """
+            Set or update combiner record.
+            combiner_data: dictionary, output of combiner.to_dict())
+        """
+        combiners = get_config('control', 'combiners')
+        from datetime import datetime
+        combiner_data['updated_at'] = str(datetime.now())
+        found = False
+        if combiners is None or len(combiners) == 0:
+            print("adding the first  combiner! {}".format(combiner_data), flush=True)
+            combiners = []
+            combiners.append(combiner_data)
+        else:
+            for c in combiners:
+                if c['name'] == combiner_data['name']:
+                    c.update(combiner_data)
+                    found = True
+
+        if not found:
+            combiners.append(combiner_data)
+        #combiners.update(combiner_data)
+        set_config('control', 'combiners', combiners)
+
+        #set_config('control', 'combiners', combiner_data)
+        #self.combiners.update_one({'name': combiner_data['name']}, {
+        #    '$set': combiner_data}, True)
+
+    def delete_combiner(self, combiner):
+        """ """
+        new_combiners = []
+        combiners = get_config('control', 'combiners')
+        for c in combiners:
+            if c['name'] != combiner:
+                new_combiners.append(c)
+        set_config('control', 'combiners', new_combiners)
+        #try:
+        #    self.combiners.delete_one({'name': combiner})
+        #except Exception:
+        #    print("WARNING, failed to delete combiner: {}".format(
+        #        combiner), flush=True)
+
+    def set_client(self, client_data):
+        """
+            Set or update client record.
+            client_data: dictionarys
+        """
+        #client_data['updated_at'] = str(datetime.now())
+        #self.clients.update_one({'name': client_data['name']}, {
+        #    '$set': client_data}, True)
+        clients = get_config('control', 'clients')
+        from datetime import datetime
+        client_data['updated_at'] = str(datetime.now())
+
+        found = False
+        if clients is None or len(clients) == 0:
+            clients = []
+
+
+        for c in clients:
+            if c['name'] == client_data['name']:
+                c.update(client_data)
+                found = True
+
+        if not found:
+            clients.append(client_data)
+        #combiners.update(combiner_data)
+        set_config('control', 'clients', clients)
+    def get_client(self, name):
+        """ """
+        clients = get_config('control', 'clients')
+        if clients:
+            for c in clients:
+                if c['name'] == name:
+                    return c
+        return None
+        #try:
+        #    ret = self.clients.find({'key': name})
+        #    if list(ret) == []:
+        #        return None
+        #    else:
+        #        return ret
+        #except Exception:
+        #    return None
+
+    def list_clients(self):
+        """ """
+        clients = get_config('control', 'clients')
+        if clients is None:
+            return []
+        return clients
+        #try:
+        #     ret = self.clients.find()
+        #     return list(ret)
+        # except Exception:
+        #     return None
+
+    def drop_control(self):
+        """ """
+        # Control
+        set_config('control', 'status', 'disabled')
+        set_config('control', 'storage_backend', None)
+        set_config('control', 'reducer', None)
+        set_config('control', 'combiners', [])
+        set_config('control', 'clients', [])
+        #set_config('control', 'round_time', None)
+
+
+        #self.state.drop()
+        #self.control_config.drop()
+        #self.control.drop()
+
+        self.drop_models()
+
+    def drop_models(self):
+        """ """
+        set_config('control', 'round', None)
+        set_config('control', 'psutil_monitoring', None)
+        set_config('control', 'model', None)
+        set_config('control', 'combiner_round_time', None)
+        #self.model.drop()
+        #self.combiner_round_time.drop()
+        #self.status.drop()
+        #self.psutil_monitoring.drop()
+        #self.round_time.drop()
+        #self.round.drop()
+
+    def update_client_status(self, client_data, status, role):
+        """
+            Set or update client status.
+            assign roles to the active clients (trainer, validator, trainer-validator)
+        """
+        #self.clients.update_one({"name": client_data['name']},
+        #                        {"$set":
+        #                            {
+        #                                "status": status,
+        #                                "role": role
+        #                            }
+        #                        })
+        #
+        clients = get_config('control', 'clients')
+        from datetime import datetime
+        #client_data['updated_at'] = str(datetime.now())
+
+        for c in clients:
+            if c['name'] == client_data['name']:
+                c.update({"status": status, "role": role})
+
+        #combiners.update(combiner_data)
+        set_config('control', 'clients', clients)

--- a/fedn/fedn/combiner.py
+++ b/fedn/fedn/combiner.py
@@ -16,7 +16,8 @@ from fedn.clients.combiner.roundcontrol import RoundControl
 from fedn.common.net.connect import ConnectorCombiner, Status
 from fedn.common.net.grpc.server import Server
 from fedn.common.storage.s3.s3repo import S3ModelRepository
-from fedn.common.tracer.mongotracer import MongoTracer
+
+#from fedn.common.tracer.mongotracer import MongoTracer
 
 VALID_NAME_REGEX = '^[a-zA-Z0-9_-]*$'
 
@@ -110,8 +111,11 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
             config['storage']['storage_config'])
         self.server = Server(self, self.modelservice, grpc_config)
 
-        self.tracer = MongoTracer(
-            config['statestore']['mongo_config'], config['statestore']['network_id'])
+        self.tracer = None
+        if not self.tracer:
+            print("tracer disabled")
+        #self.tracer = MongoTracer(
+        #    config['statestore']['mongo_config'], config['statestore']['network_id'])
 
         self.control = RoundControl(
             self.id, self.repository, self, self.modelservice)
@@ -298,7 +302,8 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
     def _send_status(self, status):
 
-        self.tracer.report(status)
+        if self.tracer:
+            self.tracer.report(status)
         for name, client in self.clients.items():
             try:
                 q = client[fedn.Channel.STATUS]

--- a/fedn/fedn/common/storage/db/mongo.py
+++ b/fedn/fedn/common/storage/db/mongo.py
@@ -1,13 +1,9 @@
+
+
 import pymongo
 
-
 def connect_to_mongodb(config, network_id):
-    """
-
-    :param config:
-    :param network_id:
-    :return:
-    """
+   
     try:
         mc = pymongo.MongoClient(**config)
         # This is so that we check that the connection is live
@@ -19,12 +15,9 @@ def connect_to_mongodb(config, network_id):
         raise
 
 
-def drop_mongodb(config, network_id):
-    """
 
-    :param config:
-    :param network_id:
-    """
+def drop_mongodb(config, network_id):
+   
     try:
         mc = pymongo.MongoClient(**config)
         mdb = mc[network_id]

--- a/fedn/fedn/common/tracer/mongotracer.py
+++ b/fedn/fedn/common/tracer/mongotracer.py
@@ -4,14 +4,12 @@ from datetime import datetime
 import psutil
 from google.protobuf.json_format import MessageToDict
 
-from fedn.common.storage.db.mongo import connect_to_mongodb
+#from fedn.common.storage.db.mongo import connect_to_mongodb
 from fedn.common.tracer.tracer import Tracer
 
-
+"""
 class MongoTracer(Tracer):
-    """
 
-    """
 
     def __init__(self, mongo_config, network_id):
         try:
@@ -32,7 +30,7 @@ class MongoTracer(Tracer):
     def report(self, msg):
         """
 
-        :param msg:
+        #:param msg:
         """
         data = MessageToDict(msg, including_default_value_fields=True)
 
@@ -93,8 +91,8 @@ class MongoTracer(Tracer):
     def set_latest_time(self, round, round_time):
         """
 
-        :param round:
-        :param round_time:
+        #:param round:
+        #:param round_time:
         """
         self.round_time.update_one({'key': 'round_time'}, {
                                    '$push': {'round': round}}, True)
@@ -104,8 +102,8 @@ class MongoTracer(Tracer):
     def set_combiner_time(self, round, round_time):
         """
 
-        :param round:
-        :param round_time:
+        #:param round:
+        #:param round_time:
         """
         self.combiner_round_time.update_one({'key': 'combiner_round_time'}, {
                                             '$push': {'round': round}}, True)
@@ -120,7 +118,7 @@ class MongoTracer(Tracer):
     def set_round_meta(self, round_meta):
         """
 
-        :param round_meta:
+        #:param round_meta:
         """
         self.round.update_one({'key': str(round_meta['round_id'])}, {
                               '$push': {'combiners': round_meta}}, True)
@@ -128,7 +126,7 @@ class MongoTracer(Tracer):
     def set_round_meta_reducer(self, round_meta):
         """
 
-        :param round_meta:
+        #:param round_meta:
         """
         self.round.update_one({'key': str(round_meta['round_id'])}, {
                               '$push': {'reducer': round_meta}}, True)
@@ -136,7 +134,7 @@ class MongoTracer(Tracer):
     def get_latest_round(self):
         """
 
-        :return:
+        #:return:
         """
         for post in self.round_time.find({'key': 'round_time'}):
             last_round = post['round'][-1]
@@ -145,7 +143,7 @@ class MongoTracer(Tracer):
     def ps_util_monitor(self, round=None):
         """
 
-        :param round:
+        #:param round:
         """
         global running
         running = True
@@ -168,7 +166,7 @@ class MongoTracer(Tracer):
     def start_monitor(self, round=None):
         """
 
-        :param round:
+        #:param round:
         """
         global t
         # create thread and start it
@@ -185,3 +183,4 @@ class MongoTracer(Tracer):
         running = False
         # wait for thread's end
         t.join()
+"""

--- a/fedn/fedn/reducer.py
+++ b/fedn/fedn/reducer.py
@@ -40,7 +40,7 @@ class Reducer:
             print("REDUCER: Failed to retrive Reducer config, exiting.")
             raise MissingReducerConfiguration()
 
-        print(config, flush=True)
+        print("ReducerConfig: {}".format(config), flush=True)
         # Validate reducer name
         match = re.search(VALID_NAME_REGEX, config['name'])
         if not match:

--- a/fedn/setup.py
+++ b/fedn/setup.py
@@ -33,7 +33,8 @@ setup(
         "plotly",
         "pandas",
         "bokeh<3.0.0",
-        "networkx"
+        "networkx",
+        "redis",
     ],
     license='Apache 2.0',
     zip_safe=False,


### PR DESCRIPTION
## Description
Redis for backend statestore

As there are interfaces for statestore and modelstore the option to switch to redis for statestore is introduced.

### caveats/not finished
the mongotracer has been deeply integrated in several places. This should be replaced with a factory and a clean interface such that any tracer could be used for distribtuted logging. perhaps fluentd? 
The tracer has been disabled for now.
