### PR TITLE
Feature/SK-481 | Add option to delete intermediate models from disk

### DIFF
--- a/fedn/fedn/common/storage/models/modelstorage.py
+++ b/fedn/fedn/common/storage/models/modelstorage.py
@@ -5,37 +5,66 @@ class ModelStorage(ABC):
 
     @abstractmethod
     def exist(self, model_id):
-        """
+        """ Check if model exists in storage
 
-        :param model_id:
+        :param model_id: The model id
+        :type model_id: str
+        :return: True if model exists, False otherwise
+        :rtype: bool
         """
         pass
 
     @abstractmethod
     def get(self, model_id):
-        """
+        """ Get model from storage
 
-        :param model_id:
+        :param model_id: The model id
+        :type model_id: str
+        :return: The model
+        :rtype: object
         """
         pass
 
-    #    @abstractmethod
-    #    def set(self, model_id, model):
-    #        pass
-
     @abstractmethod
     def get_meta(self, model_id):
-        """
+        """ Get model metadata from storage
 
-        :param model_id:
+        :param model_id: The model id
+        :type model_id: str
+        :return: The model metadata
+        :rtype: dict
         """
         pass
 
     @abstractmethod
     def set_meta(self, model_id, model_metadata):
-        """
+        """ Set model metadata in storage
 
-        :param model_id:
-        :param model_metadata:
+        :param model_id: The model id
+        :type model_id: str
+        :param model_metadata: The model metadata
+        :type model_metadata: dict
+        :return: True if successful, False otherwise
+        :rtype: bool
+        """
+        pass
+
+    @abstractmethod
+    def delete(self, model_id):
+        """ Delete model from storage
+
+        :param model_id: The model id
+        :type model_id: str
+        :return: True if successful, False otherwise
+        :rtype: bool
+        """
+        pass
+
+    @abstractmethod
+    def delete_all(self):
+        """ Delete all models from storage
+
+        :return: True if successful, False otherwise
+        :rtype: bool
         """
         pass

--- a/fedn/fedn/common/storage/models/tempmodelstorage.py
+++ b/fedn/fedn/common/storage/models/tempmodelstorage.py
@@ -85,3 +85,45 @@ class TempModelStorage(ModelStorage):
         :param model_metadata:
         """
         self.models_metadata.update({model_id: model_metadata})
+
+    # Delete model from disk
+    def delete(self, model_id):
+        """ Delete model from temp disk/storage
+
+        :param model_id: model id
+        :type model_id: str
+        :return: True if successful, False otherwise
+        :rtype: bool
+        """
+        try:
+            os.remove(os.path.join(self.default_dir, str(model_id)))
+            print("TEMPMODELSTORAGE: Deleted model with id: {}".format(model_id), flush=True)
+            # Delete id from metadata and models dict
+            del self.models_metadata[model_id]
+            del self.models[model_id]
+        except FileNotFoundError:
+            print("Could not delete model from disk. File not found!", flush=True)
+            return False
+        return True
+
+    # Delete all models from disk
+    def delete_all(self):
+        """ Delete all models from temp disk/storage
+
+        :return: True if successful, False otherwise
+        :rtype: bool
+        """
+        ids_pop = []
+        for model_id in self.models.keys():
+            try:
+                os.remove(os.path.join(self.default_dir, str(model_id)))
+                print("TEMPMODELSTORAGE: Deleted model with id: {}".format(model_id), flush=True)
+                # Add id to list of ids to pop/delete from metadata and models dict
+                ids_pop.append(model_id)
+            except FileNotFoundError:
+                print("TEMPMODELSTORAGE: Could not delete model {} from disk. File not found!".format(model_id), flush=True)
+        # Remove id from metadata and models dict
+        for model_id in ids_pop:
+            del self.models_metadata[model_id]
+            del self.models[model_id]
+        return True

--- a/fedn/fedn/common/storage/models/tests/test_tempmodelstorage.py
+++ b/fedn/fedn/common/storage/models/tests/test_tempmodelstorage.py
@@ -1,0 +1,104 @@
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from fedn.common.storage.models.tempmodelstorage import TempModelStorage
+
+
+class TestTempModelStorage(unittest.TestCase):
+
+    def setUp(self):
+        # Setup mock for os.environ.get for FEDN_MODEL_DIR
+        self.patcher = patch('os.environ.get')
+        self.mock_get = self.patcher.start()
+        # Return value of mock should same folder as this file
+        self.mock_get.return_value = os.path.dirname(os.path.realpath(__file__))
+
+        # Setup storage
+        self.storage = TempModelStorage()
+
+        # add mock data to storage dicts
+        self.storage.models = {"model_id1": "model1", "model_id2": "model2"}
+        self.storage.models_metadata = {"model_id1": "model1", "model_id2": "model2"}
+
+        # Create mock file as BytesIO object
+        self.mock_file = MagicMock()
+        self.mock_file.read.return_value = "model1"
+        self.mock_file.seek.return_value = 0
+        self.mock_file.write.return_value = None
+
+    # Test that the storage is initialized with the correct default directory and data structures
+    def test_init(self):
+        self.assertEqual(self.storage.default_dir, os.path.dirname(os.path.realpath(__file__)))
+        self.assertEqual(self.storage.models, {"model_id1": "model1", "model_id2": "model2"})
+        self.assertEqual(self.storage.models_metadata, {"model_id1": "model1", "model_id2": "model2"})
+
+    # Test that the storage can get a model
+
+    def test_get(self):
+        """ Test that the storage can get a model """
+
+        # Test that it returns None if model_id does not exist
+        self.assertEqual(self.storage.get("model_id3"), None)
+
+        # TODO: Patch fedn.ModelStatus.OK and open to return True and mock_file respectively
+
+    def test_get_metadata(self):
+        """ Test that the storage can get a model metadata """
+
+        # Test that it returns KeyError if model_id does not exist
+        with self.assertRaises(KeyError):
+            self.storage.get_meta("model_id3")
+
+        # Test that it returns the correct metadata if model_id exists
+        self.assertEqual(self.storage.get_meta("model_id1"), "model1")
+
+    def test_set_meta(self):
+        """ Test that the storage can set a model metadata """
+
+        # Test that it returns the correct metadata if model_id exists
+        self.storage.set_meta("model_id1", "model3")
+        self.assertEqual(self.storage.get_meta("model_id1"), "model3")
+
+    def test_delete(self):
+        """ Test that the storage can delete a model """
+
+        # Test that it returns False if model_id does not exist
+        self.assertEqual(self.storage.delete("model_id3"), False)
+
+        # Patch os.remove to return True
+        with patch('os.remove', return_value=True) as mock_remove:
+
+            # Test that it returns True if model_id exists
+            self.assertEqual(self.storage.delete("model_id1"), True)
+
+            # Test that os.remove is called with the correct path
+            mock_remove.assert_called_with(os.path.join(self.storage.default_dir, "model_id1"))
+
+            # Test that the model is removed from the storage
+            self.assertEqual(self.storage.models, {"model_id2": "model2"})
+
+            # Test that the model metadata is removed from the storage
+            self.assertEqual(self.storage.models_metadata, {"model_id2": "model2"})
+
+    def test_delete_all(self):
+        """ Test that the storage can delete all models """
+
+        # Patch os.remove to return True
+        with patch('os.remove', return_value=True) as mock_remove:
+
+            # Test that it returns True if model_id exists
+            self.assertEqual(self.storage.delete_all(), True)
+
+            # Test that os.remove is called with the correct path
+            mock_remove.assert_called_with(os.path.join(self.storage.default_dir, "model_id2"))
+
+            # Test that the model is removed from the storage
+            self.assertEqual(self.storage.models, {})
+
+            # Test that the model metadata is removed from the storage
+            self.assertEqual(self.storage.models_metadata, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/fedn/fedn/common/tracer/mongotracer.py
+++ b/fedn/fedn/common/tracer/mongotracer.py
@@ -17,23 +17,34 @@ class MongoTracer(Tracer):
             self.status = self.mdb['control.status']
             self.rounds = self.mdb['control.rounds']
             self.sessions = self.mdb['control.sessions']
+            self.validations = self.mdb['control.validations']
         except Exception as e:
             print("FAILED TO CONNECT TO MONGO, {}".format(e), flush=True)
             self.status = None
             raise
 
-    def report(self, msg):
-        """
+    def report_status(self, msg):
+        """Write status message to the database.
 
-        :param msg:
+        :param msg: The status message.
         """
         data = MessageToDict(msg, including_default_value_fields=True)
 
         if self.status is not None:
             self.status.insert_one(data)
 
-    def drop_status(self):
+    def report_validation(self, validation):
+        """Write model validation to the database.
+
+        :param validation: The model validation.
         """
+        data = MessageToDict(validation, including_default_value_fields=True)
+
+        if self.validations is not None:
+            self.validations.insert_one(data)
+
+    def drop_status(self):
+        """Drop the status collection.
 
         """
         if self.status:

--- a/fedn/fedn/common/tracer/tracer.py
+++ b/fedn/fedn/common/tracer/tracer.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 class Tracer(ABC):
     @abstractmethod
-    def report(self, msg):
+    def report_status(self, msg):
         """
 
         :param msg:

--- a/fedn/fedn/network/clients/client.py
+++ b/fedn/fedn/network/clients/client.py
@@ -488,7 +488,7 @@ class Client:
                     meta['config'] = request.data
 
                     if model_id is not None:
-                        # Notify the combiner that a model update is available
+                        # Send model update to combiner
                         update = fedn.ModelUpdate()
                         update.sender.name = self.name
                         update.sender.role = fedn.WORKER

--- a/fedn/fedn/network/combiner/aggregators/aggregator.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregator.py
@@ -69,7 +69,7 @@ class Aggregator(ABC):
             else:
                 self.server.report_status("AGGREGATOR({}): Invalid model update, skipping.".format(self.name))
         except Exception as e:
-            self.server.report_status("AGGREGATOR({}): Failed to receive candidate model! {}".format(self.name, e),
+            self.server.report_status("AGGREGATOR({}): Failed to receive model update! {}".format(self.name, e),
                                       log_level=fedn.Status.WARNING)
             pass
 
@@ -86,7 +86,8 @@ class Aggregator(ABC):
         self.report_validation(model_validation)
         self.server.report_status("AGGREGATOR({}): callback processed validation {}".format(self.name, model_validation.model_id),
                                   log_level=fedn.Status.INFO)
-        #total_expected_validations = self.server.nr_active_validators()
+
+        # total_expected_validations = self.server.nr_active_validators()
         # Check if all validations have been received for the model and delete the model if so
         # if total_expected_validations == self.get_total_validations(model_validation.model_id):
         #    self.server.report_status("AGGREGATOR({}): All validations received for model {}, deleting model.".format(self.name, model_validation.model_id),

--- a/fedn/fedn/network/combiner/aggregators/aggregator.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregator.py
@@ -73,19 +73,6 @@ class Aggregator(ABC):
                                       log_level=fedn.Status.WARNING)
             pass
 
-    def on_model_validation(self, model_validation):
-        """ Callback when a new client model validation is recieved.
-            Performs (optional) pre-processing and then writes the validation
-            to the database. Override in subclass as needed.
-
-        :param validation: Dict containing validation data sent by client.
-                           Must be valid JSON.
-        :type validation: dict
-        """
-
-        self.server.report_status("AGGREGATOR({}): callback processed validation {}".format(self.name, model_validation.model_id),
-                                  log_level=fedn.Status.INFO)
-
     def _validate_model_update(self, model_update):
         """ Validate the model update.
 

--- a/fedn/fedn/network/combiner/aggregators/aggregator.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregator.py
@@ -86,14 +86,14 @@ class Aggregator(ABC):
         self.report_validation(model_validation)
         self.server.report_status("AGGREGATOR({}): callback processed validation {}".format(self.name, model_validation.model_id),
                                   log_level=fedn.Status.INFO)
-        total_expected_validations = self.server.nr_active_validators()
+        #total_expected_validations = self.server.nr_active_validators()
         # Check if all validations have been received for the model and delete the model if so
-        if total_expected_validations == self.get_total_validations(model_validation.model_id):
-            self.server.report_status("AGGREGATOR({}): All validations received for model {}, deleting model.".format(self.name, model_validation.model_id),
-                                      log_level=fedn.Status.INFO)
-            self.modelservice.models.delete(model_validation.model_id)
-            # Delete the model from the validation dictionary
-            # del self.validations[model_validation.model_id]
+        # if total_expected_validations == self.get_total_validations(model_validation.model_id):
+        #    self.server.report_status("AGGREGATOR({}): All validations received for model {}, deleting model.".format(self.name, model_validation.model_id),
+        #                              log_level=fedn.Status.INFO)
+        #    self.modelservice.models.delete(model_validation.model_id)
+        # Delete the model from the validation dictionary
+        # del self.validations[model_validation.model_id]
 
     def report_validation(self, request):
         """ Report validation to dict.

--- a/fedn/fedn/network/combiner/aggregators/aggregator.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregator.py
@@ -30,6 +30,8 @@ class Aggregator(ABC):
         self.modelservice = modelservice
         self.control = control
         self.model_updates = queue.Queue()
+        # Track the number of model validations performed
+        self.validations = {}
 
     @abstractmethod
     def combine_models(self, nr_expected_models=None, nr_required_models=1, helper=None, timeout=180):
@@ -81,9 +83,44 @@ class Aggregator(ABC):
         :type validation: dict
         """
 
-        # self.report_validation(validation)
+        self.report_validation(model_validation)
         self.server.report_status("AGGREGATOR({}): callback processed validation {}".format(self.name, model_validation.model_id),
                                   log_level=fedn.Status.INFO)
+        total_expected_validations = self.server.nr_active_validators()
+        # Check if all validations have been received for the model and delete the model if so
+        if total_expected_validations == self.get_total_validations(model_validation.model_id):
+            self.server.report_status("AGGREGATOR({}): All validations received for model {}, deleting model.".format(self.name, model_validation.model_id),
+                                      log_level=fedn.Status.INFO)
+            self.modelservice.models.delete(model_validation.model_id)
+            # Delete the model from the validation dictionary
+            # del self.validations[model_validation.model_id]
+
+    def report_validation(self, request):
+        """ Report validation to dict.
+
+        :param request: A validation request.
+        :type request: object
+        """
+        client_name = request.sender.name
+        model_id = request.model_id
+        if model_id not in self.validations.keys():
+            self.validations[model_id] = [client_name]
+        else:
+            self.validations[model_id].append(client_name)
+
+    # Get total number of validations for a model
+    def get_total_validations(self, model_id):
+        """ Get total number of validations for a model.
+
+        :param model_id: A model id.
+        :type model_id: str
+        :return: The total number of validations.
+        :rtype: int
+        """
+        if model_id not in self.validations.keys():
+            return 0
+        else:
+            return len(self.validations[model_id])
 
     def _validate_model_update(self, model_update):
         """ Validate the model update.

--- a/fedn/fedn/network/combiner/aggregators/aggregator.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregator.py
@@ -30,11 +30,9 @@ class Aggregator(ABC):
         self.modelservice = modelservice
         self.control = control
         self.model_updates = queue.Queue()
-        # Track the number of model validations performed
-        self.validations = {}
 
     @abstractmethod
-    def combine_models(self, nr_expected_models=None, nr_required_models=1, helper=None, timeout=180):
+    def combine_models(self, nr_expected_models=None, nr_required_models=1, helper=None, timeout=180, delete_models=True):
         """Routine for combining model updates. Implemented in subclass.
 
         :param nr_expected_models: Number of expected models. If None, wait for all models.
@@ -45,6 +43,8 @@ class Aggregator(ABC):
         :type helper: :class: `fedn.utils.plugins.helperbase.HelperBase`
         :param timeout: Timeout in seconds to wait for models to be combined.
         :type timeout: int
+        :param delete_models: Delete client models after combining.
+        :type delete_models: bool
         :return: A combined model.
         """
         pass
@@ -83,45 +83,8 @@ class Aggregator(ABC):
         :type validation: dict
         """
 
-        self.report_validation(model_validation)
         self.server.report_status("AGGREGATOR({}): callback processed validation {}".format(self.name, model_validation.model_id),
                                   log_level=fedn.Status.INFO)
-
-        # total_expected_validations = self.server.nr_active_validators()
-        # Check if all validations have been received for the model and delete the model if so
-        # if total_expected_validations == self.get_total_validations(model_validation.model_id):
-        #    self.server.report_status("AGGREGATOR({}): All validations received for model {}, deleting model.".format(self.name, model_validation.model_id),
-        #                              log_level=fedn.Status.INFO)
-        #    self.modelservice.models.delete(model_validation.model_id)
-        # Delete the model from the validation dictionary
-        # del self.validations[model_validation.model_id]
-
-    def report_validation(self, request):
-        """ Report validation to dict.
-
-        :param request: A validation request.
-        :type request: object
-        """
-        client_name = request.sender.name
-        model_id = request.model_id
-        if model_id not in self.validations.keys():
-            self.validations[model_id] = [client_name]
-        else:
-            self.validations[model_id].append(client_name)
-
-    # Get total number of validations for a model
-    def get_total_validations(self, model_id):
-        """ Get total number of validations for a model.
-
-        :param model_id: A model id.
-        :type model_id: str
-        :return: The total number of validations.
-        :rtype: int
-        """
-        if model_id not in self.validations.keys():
-            return 0
-        else:
-            return len(self.validations[model_id])
 
     def _validate_model_update(self, model_update):
         """ Validate the model update.

--- a/fedn/fedn/network/combiner/aggregators/fedavg.py
+++ b/fedn/fedn/network/combiner/aggregators/fedavg.py
@@ -26,7 +26,7 @@ class FedAvg(Aggregator):
 
         self.name = "FedAvg"
 
-    def combine_models(self, helper=None, time_window=180, max_nr_models=100):
+    def combine_models(self, helper=None, time_window=180, max_nr_models=100, delete_models=True):
         """Aggregate model updates in the queue by computing an incremental
            weighted average of parameters.
 
@@ -36,6 +36,8 @@ class FedAvg(Aggregator):
         :type time_window: int, optional
         :param max_nr_models: The maximum number of updates aggregated, defaults to 100
         :type max_nr_models: int, optional
+        :param delete_models: Delete models from storage after aggregation, defaults to True
+        :type delete_models: bool, optional
         :return: The global model and metadata
         :rtype: tuple
         """
@@ -69,9 +71,10 @@ class FedAvg(Aggregator):
 
                 nr_aggregated_models += 1
                 # Delete model from storage
-                self.modelservice.models.delete(model_id)
-                self.server.report_status(
-                    "AGGREGATOR({}): Deleted model update {} from storage.".format(self.name, model_id))
+                if delete_models:
+                    self.modelservice.models.delete(model_id)
+                    self.server.report_status(
+                        "AGGREGATOR({}): Deleted model update {} from storage.".format(self.name, model_id))
                 self.model_updates.task_done()
             except Exception as e:
                 self.server.report_status(

--- a/fedn/fedn/network/combiner/aggregators/fedavg.py
+++ b/fedn/fedn/network/combiner/aggregators/fedavg.py
@@ -68,6 +68,10 @@ class FedAvg(Aggregator):
                         model, model_next, metadata['num_examples'], total_examples)
 
                 nr_aggregated_models += 1
+                # Delete model from storage
+                self.modelservice.models.delete(model_id)
+                self.server.report_status(
+                    "AGGREGATOR({}): Deleted model update {} from storage.".format(self.name, model_id))
                 self.model_updates.task_done()
             except Exception as e:
                 self.server.report_status(

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -370,9 +370,8 @@ class RoundController:
                             self.server.tracer.set_round_combiner_data(round_meta)
                             if round_config['delete_models_storage'] == 'True':
                                 self.modelservice.models.delete(round_config['model_id'])
-                                # Print deleting model from storage
-                                print("ROUNDCONTROL: Deleting model {} from storage".format(
-                                    round_config['model_id']))
+                                self.server.report_status("ROUNDCONTROL: Deleting model {} from storage".format(
+                                    round_config['model_id']), flush=True)
                         elif round_config['task'] == 'validation' or round_config['task'] == 'inference':
                             self.execute_validation_round(round_config)
                         else:

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -199,6 +199,7 @@ class RoundController:
 
         # If the model is already in memory at the server we do not need to do anything.
         if self.modelservice.models.exist(model_id):
+            print("MODEL EXISTST (NOT)", flush=True)
             return
 
         # If not, download it and stage it in memory at the combiner.

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -58,10 +58,7 @@ class RoundController:
         return round_config['_job_id']
 
     def load_model_update(self, helper, model_id):
-        """Load model update in native format.
-
-        First the model is loaded in BytesIO, then the helper is used to
-        parse it into its native model format (Keras, PyTorch, etc).
+        """Load model update in its native format.
 
         :param helper: An instance of :class: `fedn.utils.helpers.HelperBase`, ML framework specific helper, defaults to None
         :type helper: class: `fedn.utils.helpers.HelperBase`
@@ -187,7 +184,7 @@ class RoundController:
         self.server.request_model_validation(model_id, config, clients)
 
     def stage_model(self, model_id, timeout_retry=3, retry=2):
-        """Download model from persistent storage and set in modelservice.
+        """Download a model from persistent storage and set in modelservice.
 
         :param model_id: ID of the model update object to stage.
         :type model_id: str

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -201,7 +201,7 @@ class RoundController:
         if self.modelservice.models.exist(model_id):
             print("MODEL EXISTST (NOT)", flush=True)
             return
-
+        print("MODEL STAGING", flush=True)
         # If not, download it and stage it in memory at the combiner.
         tries = 0
         while True:
@@ -364,6 +364,7 @@ class RoundController:
                             round_meta['status'] = "Success"
                             round_meta['name'] = self.id
                             self.server.tracer.set_round_combiner_data(round_meta)
+                            self.modelservice.models.delete(round_config['model_id'])
                         elif round_config['task'] == 'validation' or round_config['task'] == 'inference':
                             self.execute_validation_round(round_config)
                         else:

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -163,7 +163,14 @@ class RoundController:
 
         try:
             helper = get_helper(config['helper_type'])
-            model, data = self.aggregator.combine_models(helper)
+            # print config delete_models_storage
+            print("ROUNDCONTROL: Config delete_models_storage: {}".format(config['delete_models_storage']), flush=True)
+            if config['delete_models_storage'] == 'True':
+                delete_models = True
+            else:
+                delete_models = False
+            model, data = self.aggregator.combine_models(helper=helper,
+                                                         delete_models=delete_models)
         except Exception as e:
             print("AGGREGATION FAILED AT COMBINER! {}".format(e), flush=True)
 
@@ -361,7 +368,11 @@ class RoundController:
                             round_meta['status'] = "Success"
                             round_meta['name'] = self.id
                             self.server.tracer.set_round_combiner_data(round_meta)
-                            self.modelservice.models.delete(round_config['model_id'])
+                            if round_config['delete_models_storage'] == 'True':
+                                self.modelservice.models.delete(round_config['model_id'])
+                                # Print deleting model from storage
+                                print("ROUNDCONTROL: Deleting model {} from storage".format(
+                                    round_config['model_id']))
                         elif round_config['task'] == 'validation' or round_config['task'] == 'inference':
                             self.execute_validation_round(round_config)
                         else:

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -333,7 +333,7 @@ class RoundController:
 
         print("------------------------------------------")
         self.server.report_status(
-            "ROUNDCONTROL: TRAINING ROUND COMPLETED.", flush=True)
+            "ROUNDCONTROL: TRAINING ROUND COMPLETED. Aggregated model id: {}, Job id: {}".format(model_id, config['_job_id']), flush=True)
         print("\n")
         return data
 

--- a/fedn/fedn/network/combiner/server.py
+++ b/fedn/fedn/network/combiner/server.py
@@ -354,20 +354,13 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
             raise
 
     def _send_status(self, status):
-        """ Send a status to tracer and update all clients.
+        """ Report a status to tracer.
 
-        :param status: the status to send
+        :param status: the status to report
         :type status: :class:`fedn.common.net.grpc.fedn_pb2.Status`
         """
 
-        self.tracer.report(status)
-        for name, client in self.clients.items():
-            try:
-                q = client[fedn.Channel.STATUS]
-                status.timestamp = str(datetime.now())
-                q.put(status)
-            except KeyError:
-                pass  # TODO: Don't pass silently
+        self.tracer.report_status(status)
 
     def __register_heartbeat(self, client):
         """ Register a client if first time connecting. Update heartbeat timestamp.
@@ -522,7 +515,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         :return: the response
         :rtype: :class:`fedn.common.net.grpc.fedn_pb2.Response`
         """
-        # Add the status message to all subscribers of the status channel
+
         self._send_status(status)
 
         response = fedn.Response()
@@ -801,6 +794,15 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
             request.sender.name)
         return response  # TODO Fill later
 
+    def register_model_validation(self, validation):
+        """Register a model validation.
+
+        :param validation: the model validation
+        :type validation: :class:`fedn.common.net.grpc.fedn_pb2.ModelValidation` 
+        """
+
+        self.tracer.report_validation(validation)
+
     def SendModelValidation(self, request, context):
         """ Send a model validation response.
 
@@ -811,12 +813,15 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         :return: the response
         :rtype: :class:`fedn.common.net.grpc.fedn_pb2.Response`
         """
-        self.control.aggregator.on_model_validation(request)
-        print("ORCHESTRATOR received validation ", flush=True)
+        self.report_status("Recieved ModelValidation from {}".format(request.sender.name),
+                           log_level=fedn.Status.INFO)
+
+        self.register_model_validation(request)
+
         response = fedn.Response()
         response.response = "RECEIVED ModelValidation {} from client  {}".format(
             response, response.sender.name)
-        return response  # TODO Fill later
+        return response
 
     ####################################################################################################################
 

--- a/fedn/fedn/network/combiner/server.py
+++ b/fedn/fedn/network/combiner/server.py
@@ -798,7 +798,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         """Register a model validation.
 
         :param validation: the model validation
-        :type validation: :class:`fedn.common.net.grpc.fedn_pb2.ModelValidation` 
+        :type validation: :class:`fedn.common.net.grpc.fedn_pb2.ModelValidation`
         """
 
         self.tracer.report_validation(validation)

--- a/fedn/fedn/network/controller/controlbase.py
+++ b/fedn/fedn/network/controller/controlbase.py
@@ -129,7 +129,7 @@ class ControlBase(ABC):
         if not last_round:
             return 0
         else:
-            return last_round['key']
+            return last_round['round_id']
 
     def get_latest_round(self):
         round = self.statestore.get_latest_round()

--- a/fedn/fedn/network/controller/controlbase.py
+++ b/fedn/fedn/network/controller/controlbase.py
@@ -1,3 +1,4 @@
+import os
 import uuid
 from abc import ABC, abstractmethod
 
@@ -193,15 +194,17 @@ class ControlBase(ABC):
 
         helper = self.get_helper()
         if model is not None:
-            print("Saving model to disk...", flush=True)
+            print("CONTROL: Saving model file temporarily to disk...", flush=True)
             outfile_name = helper.save(model)
-            print("DONE", flush=True)
-            print("Uploading model to Minio...", flush=True)
+            print("CONTROL: Uploading model to Minio...", flush=True)
             model_id = self.model_repository.set_model(
                 outfile_name, is_file=True)
 
-            print("DONE", flush=True)
+            print("CONTROL: Deleting temporary model file...", flush=True)
+            os.unlink(outfile_name)
 
+        print("CONTROL: Committing model {} to global model trail in statestore...".format(
+            model_id), flush=True)
         self.statestore.set_latest(model_id)
 
     def get_combiner(self, name):

--- a/fedn/fedn/network/dashboard/restservice.py
+++ b/fedn/fedn/network/dashboard/restservice.py
@@ -572,6 +572,7 @@ class ReducerRestService:
                 # Get session configuration
                 round_timeout = float(request.form.get('timeout', 180))
                 rounds = int(request.form.get('rounds', 1))
+                delete_models = request.form.get('delete_models', True)
                 task = (request.form.get('task', ''))
                 clients_required = request.form.get('clients_required', 1)
                 clients_requested = request.form.get('clients_requested', 8)
@@ -601,7 +602,8 @@ class ReducerRestService:
                 latest_model_id = self.control.get_latest_model()
 
                 config = {'round_timeout': round_timeout, 'model_id': latest_model_id,
-                          'rounds': rounds, 'clients_required': clients_required,
+                          'rounds': rounds, 'delete_models_storage': delete_models,
+                          'clients_required': clients_required,
                           'clients_requested': clients_requested, 'task': task,
                           'validate': validate, 'helper_type': helper_type}
 


### PR DESCRIPTION
This is to avoid storage overflow on combiner and reducer disk when TempModelStorage (default) is used. Still a volume should be mounted to the folder where models are stored on disk. 

The design:
Deletion on the fly (round)
- after a single aggregation of a client model update, delete the client model from combiner storage/disk
- after reducer has downloaded a combined model from combiner storage/disk, delete the combined model (not implemented yet)
- On validation, wait for all clients validation response then delete the validation model from storage/disk. Obs that the last validation model will still be present and not deleted. This is just how the logic is implemented, but it also means that the combiner does not have to download the latest global model if a new session is started.

A POST parameter "delete_models" which should be a boolean has been added to /control in rest-api. Templates has not been updated to include a setting for this. 