### PR TITLE
Feature/SK-491 | Make aggregator plugin-configurable

### DIFF
--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -245,8 +245,9 @@ def reducer_cmd(ctx, host, port, secret_key, local_package, name, init):
 @click.option('-c', '--max_clients', required=False, default=30, help='The maximal number of client connections allowed.')
 @click.option('-in', '--init', required=False, default=None,
               help='Path to configuration file to (re)init combiner.')
+@click.option('-a', '--aggregator', required=False, default='fedavg', help='Filename of the aggregator module to use.')
 @click.pass_context
-def combiner_cmd(ctx, discoverhost, discoverport, token, name, host, port, fqdn, secure, verify, max_clients, init):
+def combiner_cmd(ctx, discoverhost, discoverport, token, name, host, port, fqdn, secure, verify, max_clients, init, aggregator):
     """
 
     :param ctx:
@@ -261,7 +262,8 @@ def combiner_cmd(ctx, discoverhost, discoverport, token, name, host, port, fqdn,
     :param init:
     """
     config = {'discover_host': discoverhost, 'discover_port': discoverport, 'token': token, 'host': host,
-              'port': port, 'fqdn': fqdn, 'name': name, 'secure': secure, 'verify': verify, 'max_clients': max_clients, 'init': init}
+              'port': port, 'fqdn': fqdn, 'name': name, 'secure': secure, 'verify': verify, 'max_clients': max_clients,
+              'init': init, 'aggregator': aggregator}
 
     if config['init']:
         apply_config(config)

--- a/fedn/fedn/network/combiner/aggregators/aggregatorbase.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregatorbase.py
@@ -28,7 +28,6 @@ class AggregatorBase(ABC):
         """
         self.name = self.__class__.__name__
         self.storage = storage
-        #self.id = id
         self.server = server
         self.modelservice = modelservice
         self.control = control

--- a/fedn/fedn/network/combiner/aggregators/aggregatorbase.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregatorbase.py
@@ -1,11 +1,14 @@
+import importlib
 import json
 import queue
 from abc import ABC, abstractmethod
 
 import fedn.common.net.grpc.fedn_pb2 as fedn
 
+AGGREGATOR_PLUGIN_PATH = "fedn.network.combiner.aggregators.{}"
 
-class Aggregator(ABC):
+
+class AggregatorBase(ABC):
     """ Abstract class defining an aggregator. """
 
     @abstractmethod
@@ -117,3 +120,16 @@ class Aggregator(ABC):
         data['round_id'] = config['round_id']
 
         return model_next, data, model_id
+
+
+def get_aggregator(aggregator_module_name, id, storage, server, modelservice, control):
+    """ Return an instance of the helper class.
+
+    :param helper_module_name: The name of the helper plugin module.
+    :type helper_module_name: str
+    :return: A helper instance.
+    :rtype: class: `fedn.utils.helpers.HelperBase`
+    """
+    aggregator_plugin = AGGREGATOR_PLUGIN_PATH.format(aggregator_module_name)
+    aggregator = importlib.import_module(aggregator_plugin)
+    return aggregator.Aggregator(id, storage, server, modelservice, control)

--- a/fedn/fedn/network/combiner/aggregators/aggregatorbase.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregatorbase.py
@@ -114,8 +114,16 @@ def get_aggregator(aggregator_module_name, storage, server, modelservice, contro
 
     :param helper_module_name: The name of the helper plugin module.
     :type helper_module_name: str
-    :return: A helper instance.
-    :rtype: class: `fedn.utils.helpers.HelperBase`
+    :param storage: Model repository for :class: `fedn.network.combiner.Combiner`
+    :type storage: class: `fedn.common.storage.s3.s3repo.S3ModelRepository`
+    :param server: A handle to the Combiner class :class: `fedn.network.combiner.Combiner`
+    :type server: class: `fedn.network.combiner.Combiner`
+    :param modelservice: A handle to the model service :class: `fedn.network.combiner.modelservice.ModelService`
+    :type modelservice: class: `fedn.network.combiner.modelservice.ModelService`
+    :param control: A handle to the :class: `fedn.network.combiner.round.RoundController`
+    :type control: class: `fedn.network.combiner.round.RoundController`
+    :return: An aggregator instance.
+    :rtype: class: `fedn.combiner.aggregators.AggregatorBase`
     """
     aggregator_plugin = AGGREGATOR_PLUGIN_PATH.format(aggregator_module_name)
     aggregator = importlib.import_module(aggregator_plugin)

--- a/fedn/fedn/network/combiner/aggregators/aggregatorbase.py
+++ b/fedn/fedn/network/combiner/aggregators/aggregatorbase.py
@@ -12,7 +12,7 @@ class AggregatorBase(ABC):
     """ Abstract class defining an aggregator. """
 
     @abstractmethod
-    def __init__(self, id, storage, server, modelservice, control):
+    def __init__(self, storage, server, modelservice, control):
         """ Initialize the aggregator.
 
         :param id: A reference to id of :class: `fedn.network.combiner.Combiner`
@@ -28,7 +28,7 @@ class AggregatorBase(ABC):
         """
         self.name = self.__class__.__name__
         self.storage = storage
-        self.id = id
+        #self.id = id
         self.server = server
         self.modelservice = modelservice
         self.control = control
@@ -110,7 +110,7 @@ class AggregatorBase(ABC):
         return model_next, data, model_id
 
 
-def get_aggregator(aggregator_module_name, id, storage, server, modelservice, control):
+def get_aggregator(aggregator_module_name, storage, server, modelservice, control):
     """ Return an instance of the helper class.
 
     :param helper_module_name: The name of the helper plugin module.
@@ -120,4 +120,4 @@ def get_aggregator(aggregator_module_name, id, storage, server, modelservice, co
     """
     aggregator_plugin = AGGREGATOR_PLUGIN_PATH.format(aggregator_module_name)
     aggregator = importlib.import_module(aggregator_plugin)
-    return aggregator.Aggregator(id, storage, server, modelservice, control)
+    return aggregator.Aggregator(storage, server, modelservice, control)

--- a/fedn/fedn/network/combiner/aggregators/fedavg.py
+++ b/fedn/fedn/network/combiner/aggregators/fedavg.py
@@ -1,8 +1,8 @@
 import fedn.common.net.grpc.fedn_pb2 as fedn
-from fedn.network.combiner.aggregators.aggregator import Aggregator
+from fedn.network.combiner.aggregators.aggregatorbase import AggregatorBase
 
 
-class FedAvg(Aggregator):
+class Aggregator(AggregatorBase):
     """ Local SGD / Federated Averaging (FedAvg) aggregator. Computes a weighted mean
         of parameter updates.
 

--- a/fedn/fedn/network/combiner/aggregators/fedavg.py
+++ b/fedn/fedn/network/combiner/aggregators/fedavg.py
@@ -19,12 +19,12 @@ class Aggregator(AggregatorBase):
 
     """
 
-    def __init__(self, id, storage, server, modelservice, control):
+    def __init__(self, storage, server, modelservice, control):
         """Constructor method"""
 
-        super().__init__(id, storage, server, modelservice, control)
+        super().__init__(storage, server, modelservice, control)
 
-        self.name = "FedAvg"
+        self.name = "fedavg"
 
     def combine_models(self, helper=None, time_window=180, max_nr_models=100, delete_models=True):
         """Aggregate model updates in the queue by computing an incremental

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -5,10 +5,7 @@ import time
 import uuid
 
 from fedn.network.combiner.aggregators.aggregatorbase import get_aggregator
-#from fedn.network.combiner.aggregators.fedavg import FedAvg
 from fedn.utils.helpers import get_helper
-
-AGGREGATOR_NAME = 'fedavg'
 
 
 class ModelUpdateError(Exception):
@@ -31,19 +28,13 @@ class RoundController:
     :type modelservice: class: `fedn.network.combiner.modelservice.ModelService`
     """
 
-    def __init__(self, id, storage, server, modelservice):
+    def __init__(self, aggregator_name, storage, server, modelservice):
 
-        self.id = id
         self.round_configs = queue.Queue()
         self.storage = storage
         self.server = server
         self.modelservice = modelservice
-
-        # TODO, make runtime configurable
-        self.aggregator = get_aggregator(AGGREGATOR_NAME, self.id, self.storage, self.server, self.modelservice, self)
-
-        # FedAvg(
-        #   self.id, self.storage, self.server, self.modelservice, self)
+        self.aggregator = get_aggregator(aggregator_name, self.storage, self.server, self.modelservice, self)
 
     def push_round_config(self, round_config):
         """Add a round_config (job description) to the inbox.
@@ -371,7 +362,7 @@ class RoundController:
                             round_meta['time_exec_training'] = time.time() - \
                                 tic
                             round_meta['status'] = "Success"
-                            round_meta['name'] = self.id
+                            round_meta['name'] = self.server.id
                             self.server.tracer.set_round_combiner_data(round_meta)
                             if round_config['delete_models_storage'] == 'True':
                                 self.modelservice.models.delete(round_config['model_id'])

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -4,8 +4,11 @@ import sys
 import time
 import uuid
 
-from fedn.network.combiner.aggregators.fedavg import FedAvg
+from fedn.network.combiner.aggregators.aggregatorbase import get_aggregator
+#from fedn.network.combiner.aggregators.fedavg import FedAvg
 from fedn.utils.helpers import get_helper
+
+AGGREGATOR_NAME = 'fedavg'
 
 
 class ModelUpdateError(Exception):
@@ -37,8 +40,10 @@ class RoundController:
         self.modelservice = modelservice
 
         # TODO, make runtime configurable
-        self.aggregator = FedAvg(
-            self.id, self.storage, self.server, self.modelservice, self)
+        self.aggregator = get_aggregator(AGGREGATOR_NAME, self.id, self.storage, self.server, self.modelservice, self)
+
+        # FedAvg(
+        #   self.id, self.storage, self.server, self.modelservice, self)
 
     def push_round_config(self, round_config):
         """Add a round_config (job description) to the inbox.

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -18,8 +18,8 @@ class RoundController:
     The round controller recieves round configurations from the global controller
     and coordinates model updates and aggregation, and model validations.
 
-    :param id: A reference to id of :class: `fedn.network.combiner.Combiner`
-    :type id: str
+    :param aggregator_name: The name of the aggregator plugin module.
+    :type aggregator_name: str
     :param storage: Model repository for :class: `fedn.network.combiner.Combiner`
     :type storage: class: `fedn.common.storage.s3.s3repo.S3ModelRepository`
     :param server: A handle to the Combiner class :class: `fedn.network.combiner.Combiner`

--- a/fedn/fedn/network/controller/control.py
+++ b/fedn/fedn/network/controller/control.py
@@ -34,8 +34,6 @@ class MisconfiguredStorageBackend(Exception):
         self.message = message
         super().__init__(self.message)
 
-# Exception class for when model is None
-
 
 class NoModelException(Exception):
     """ Exception class for when model is None """


### PR DESCRIPTION
## Description

This implements a proper plugin architecture for combiner aggregators. 

A user can now simply drop a file implementing the AggregatorBase interface in the 'network.combiner.aggregators' folder, 

aggregators/
   - aggregartorbase.py
   - fedavg.py
   - mynewaggregator.py 

then set it when starting the combiner

$ fedn run combiner --aggregator=mynewaggregator

In the future we might enable for it to be configures as part of the global round controller. For now it is a global configuration on combiner level. 