### PR TITLE
Debug: Disable global model deletion

### DIFF
--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -362,10 +362,10 @@ class RoundController:
                             round_meta['status'] = "Success"
                             round_meta['name'] = self.server.id
                             self.server.tracer.set_round_combiner_data(round_meta)
-                            if round_config['delete_models_storage'] == 'True':
-                                self.modelservice.models.delete(round_config['model_id'])
-                                self.server.report_status("ROUNDCONTROL: Deleting model {} from storage".format(
-                                    round_config['model_id']), flush=True)
+                            # if round_config['delete_models_storage'] == 'True':
+                            #     self.modelservice.models.delete(round_config['model_id'])
+                            #     self.server.report_status("ROUNDCONTROL: Deleting model {} from storage".format(
+                            #         round_config['model_id']), flush=True)
                         elif round_config['task'] == 'validation' or round_config['task'] == 'inference':
                             self.execute_validation_round(round_config)
                         else:

--- a/fedn/fedn/network/combiner/round.py
+++ b/fedn/fedn/network/combiner/round.py
@@ -362,10 +362,6 @@ class RoundController:
                             round_meta['status'] = "Success"
                             round_meta['name'] = self.server.id
                             self.server.tracer.set_round_combiner_data(round_meta)
-                            # if round_config['delete_models_storage'] == 'True':
-                            #     self.modelservice.models.delete(round_config['model_id'])
-                            #     self.server.report_status("ROUNDCONTROL: Deleting model {} from storage".format(
-                            #         round_config['model_id']), flush=True)
                         elif round_config['task'] == 'validation' or round_config['task'] == 'inference':
                             self.execute_validation_round(round_config)
                         else:

--- a/fedn/fedn/network/dashboard/restservice.py
+++ b/fedn/fedn/network/dashboard/restservice.py
@@ -643,7 +643,7 @@ class ReducerRestService:
             combiner_preferred = request.args.get('combiner', None)
 
             if combiner_preferred:
-                combiner = self.control.network.get(combiner_preferred)
+                combiner = self.control.network.get_combiner(combiner_preferred)
             else:
                 combiner = self.control.network.find_available_combiner()
 


### PR DESCRIPTION
Deleting intermediate models if task is validation was causing issues in Studio. The hypothesis is due to latency global model was deleted prior to validation. Fix: remove the deletion for validation models. 