### PR TITLE
Feature/SK-545 | Statestore init from api-server lack proper setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -85,6 +85,7 @@ services:
       - PROJECT=project
       - FLASK_DEBUG=1
       - STATESTORE_CONFIG=/app/config/settings-reducer.yaml
+      - MODELSTORAGE_CONFIG=/app/config/settings-reducer.yaml
     build:
       context: .
       args:

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -190,7 +190,7 @@ def dashboard_cmd(ctx, host, port, secret_key, local_package, name, init):
     statestore_config = fedn_config['statestore']
     if statestore_config['type'] == 'MongoDB':
         statestore = MongoStateStore(
-            network_id, statestore_config['mongo_config'], defaults=config['init'])
+            network_id, statestore_config['mongo_config'], fedn_config['storage'])
     else:
         print("Unsupported statestore type, exiting. ", flush=True)
         exit(-1)

--- a/fedn/fedn/common/config.py
+++ b/fedn/fedn/common/config.py
@@ -5,17 +5,17 @@ import yaml
 global STATESTORE_CONFIG
 global MODELSTORAGE_CONFIG
 
+
 def get_environment_config():
     """ Get the configuration from environment variables.
     """
     global STATESTORE_CONFIG
     global MODELSTORAGE_CONFIG
 
-    STATESTORE_CONFIG = os.environ.get('STATESTORE_CONFIG', 
-                                            '/workspaces/fedn/config/settings-reducer.yaml.template')
-    MODELSTORAGE_CONFIG = os.environ.get('MODELSTORAGE_CONFIG', 
-                                                '/workspaces/fedn/config/settings-reducer.yaml.template')
-
+    STATESTORE_CONFIG = os.environ.get('STATESTORE_CONFIG',
+                                       '/workspaces/fedn/config/settings-reducer.yaml.template')
+    MODELSTORAGE_CONFIG = os.environ.get('MODELSTORAGE_CONFIG',
+                                         '/workspaces/fedn/config/settings-reducer.yaml.template')
 
 
 def get_statestore_config(file=None):

--- a/fedn/fedn/common/config.py
+++ b/fedn/fedn/common/config.py
@@ -2,18 +2,33 @@ import os
 
 import yaml
 
-STATESTORE_CONFIG = os.environ.get('STATESTORE_CONFIG', '/workspaces/fedn/config/settings-reducer.yaml.template')
-MODELSTORAGE_CONFIG = os.environ.get('MODELSTORAGE_CONFIG', '/workspaces/fedn/config/settings-reducer.yaml.template')
+global STATESTORE_CONFIG
+global MODELSTORAGE_CONFIG
+
+def get_environment_config():
+    """ Get the configuration from environment variables.
+    """
+    global STATESTORE_CONFIG
+    global MODELSTORAGE_CONFIG
+
+    STATESTORE_CONFIG = os.environ.get('STATESTORE_CONFIG', 
+                                            '/workspaces/fedn/config/settings-reducer.yaml.template')
+    MODELSTORAGE_CONFIG = os.environ.get('MODELSTORAGE_CONFIG', 
+                                                '/workspaces/fedn/config/settings-reducer.yaml.template')
 
 
-def get_statestore_config(file=STATESTORE_CONFIG):
+
+def get_statestore_config(file=None):
     """ Get the statestore configuration from file.
 
-    :param file: The statestore configuration file (yaml) path.
+    :param file: The statestore configuration file (yaml) path (optional).
     :type file: str
     :return: The statestore configuration as a dict.
     :rtype: dict
     """
+    if file is None:
+        get_environment_config()
+        file = STATESTORE_CONFIG
     with open(file, 'r') as config_file:
         try:
             settings = dict(yaml.safe_load(config_file))
@@ -22,14 +37,17 @@ def get_statestore_config(file=STATESTORE_CONFIG):
     return settings["statestore"]
 
 
-def get_modelstorage_config(file=MODELSTORAGE_CONFIG):
+def get_modelstorage_config(file=None):
     """ Get the model storage configuration from file.
 
-    :param file: The model storage configuration file (yaml) path.
+    :param file: The model storage configuration file (yaml) path (optional).
     :type file: str
     :return: The model storage configuration as a dict.
     :rtype: dict
     """
+    if file is None:
+        get_environment_config()
+        file = MODELSTORAGE_CONFIG
     with open(file, 'r') as config_file:
         try:
             settings = dict(yaml.safe_load(config_file))
@@ -38,14 +56,17 @@ def get_modelstorage_config(file=MODELSTORAGE_CONFIG):
     return settings["storage"]
 
 
-def get_network_config(file=STATESTORE_CONFIG):
+def get_network_config(file=None):
     """ Get the network configuration from file.
 
-    :param file: The network configuration file (yaml) path.
+    :param file: The network configuration file (yaml) path (optional).
     :type file: str
     :return: The network id.
     :rtype: str
     """
+    if file is None:
+        get_environment_config()
+        file = STATESTORE_CONFIG
     with open(file, 'r') as config_file:
         try:
             settings = dict(yaml.safe_load(config_file))
@@ -54,14 +75,17 @@ def get_network_config(file=STATESTORE_CONFIG):
     return settings["network_id"]
 
 
-def get_controller_config(file=STATESTORE_CONFIG):
+def get_controller_config(file=None):
     """ Get the controller configuration from file.
 
-    :param file: The controller configuration file (yaml) path.
+    :param file: The controller configuration file (yaml) path (optional).
     :type file: str
     :return: The controller configuration as a dict.
     :rtype: dict
     """
+    if file is None:
+        get_environment_config()
+        file = STATESTORE_CONFIG
     with open(file, 'r') as config_file:
         try:
             settings = dict(yaml.safe_load(config_file))

--- a/fedn/fedn/network/api/server.py
+++ b/fedn/fedn/network/api/server.py
@@ -1,16 +1,18 @@
 from flask import Flask, jsonify, request
 
-from fedn.common.config import (get_controller_config, get_network_config,
-                                get_statestore_config)
+from fedn.common.config import (get_controller_config, get_modelstorage_config,
+                                get_network_config, get_statestore_config)
 from fedn.network.api.interface import API
 from fedn.network.controller.control import Control
 from fedn.network.statestore.mongostatestore import MongoStateStore
 
 statestore_config = get_statestore_config()
 network_id = get_network_config()
+modelstorage_config = get_modelstorage_config()
 statestore = MongoStateStore(
     network_id,
-    statestore_config['mongo_config']
+    statestore_config['mongo_config'],
+    modelstorage_config
 )
 control = Control(statestore=statestore)
 api = API(statestore, control)

--- a/fedn/fedn/network/statestore/mongostatestore.py
+++ b/fedn/fedn/network/statestore/mongostatestore.py
@@ -59,7 +59,7 @@ class MongoStateStore(StateStoreBase):
 
         # Storage settings
         self.set_storage_backend(model_storage_config)
-        self.__inited = True       
+        self.__inited = True
 
     def is_inited(self):
         """ Check if the statestore is intialized.


### PR DESCRIPTION
When running api-server alone without dahsboard the statestore was not properly configured due to the "default" arg for the mongostatestore constructor. The "default" arg has been removed since we rarely use control settings from file (instead send JSON to start session endpoint). 