### PR TITLE
Use latest mongodb and bump version number

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       - 9001:9001
 
   mongo:
-    image: mongo
+    image: mongo:7.0 
     restart: always
     environment:
       - MONGO_INITDB_ROOT_USERNAME=fedn_admin

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
       - 9001:9001
 
   mongo:
-    image: mongo:5.0.2
+    image: mongo
     restart: always
     environment:
       - MONGO_INITDB_ROOT_USERNAME=fedn_admin

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -120,7 +120,7 @@ class APIClient:
         return response.json()
 
     def start_session(self, session_id=None, aggregator='fedavg', model_id=None, round_timeout=180, rounds=5, round_buffer_size=-1, delete_models=True,
-                      validate=True, helper='kerashelper', min_clients=1, requested_clients=8):
+                      validate=True, helper='numpyhelper', min_clients=1, requested_clients=8):
         """ Start a new session.
 
         :param session_id: The session id to start.

--- a/fedn/fedn/network/api/interface.py
+++ b/fedn/fedn/network/api/interface.py
@@ -1011,7 +1011,7 @@ class API:
         round_buffer_size=-1,
         delete_models=False,
         validate=True,
-        helper="keras",
+        helper="numpyhelper",
         min_clients=1,
         requested_clients=8,
     ):

--- a/fedn/setup.py
+++ b/fedn/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='fedn',
-    version='0.6.0',
+    version='0.7.2',
     description="""Scaleout Federated Learning""",
     author='Scaleout Systems AB',
     author_email='contact@scaleoutsystems.com',


### PR DESCRIPTION
## Description

The present release started failing on fresh builds, probably due to incompatibility between the mongodb version used (5.0.2) and recent pymongo. This PR changes the docker-compose template to use the latest mongodb image which restres expected functionality. 
