### PR TITLE
Fixes the issue with number of files/storage growing on combiner

### DIFF
--- a/fedn/fedn/network/clients/client.py
+++ b/fedn/fedn/network/clients/client.py
@@ -568,11 +568,6 @@ class Client:
             updated_model_id = None
             meta = {'status': 'failed', 'error': str(e)}
 
-        # Push model update to combiner server
-        updated_model_id = uuid.uuid4()
-        self.set_model(out_model, str(updated_model_id))
-        meta['upload_model'] = time.time() - tic
-
         self.state = ClientState.idle
 
         return updated_model_id, meta

--- a/fedn/fedn/network/combiner/roundhandler.py
+++ b/fedn/fedn/network/combiner/roundhandler.py
@@ -343,6 +343,7 @@ class RoundHandler:
             logger.info(
                 "ROUNDCONTROL: TRAINING ROUND COMPLETED. Aggregated model id: {}, Job id: {}".format(model_id, config['_job_id']))
 
+        self.modelservice.models.delete(config['model_id'])
         return data
 
     def run(self, polling_interval=1.0):


### PR DESCRIPTION
## Description

This PR fixes a bug where clients sends the model update twice. Also, the roundhandler deletes the staged model after a training round. 

After this fix, the number of files in TempModelStorage should be equal to the number of rounds, and independent of the number of clients. 

Closes SK-646.