### PR TITLE
Feature/SK-622 | Session object should store committed_at in date format

### DIFF
--- a/fedn/fedn/network/controller/control.py
+++ b/fedn/fedn/network/controller/control.py
@@ -100,7 +100,7 @@ class Control(ControlBase):
 
         self._state = ReducerState.instructing
         config["committed_at"] = datetime.datetime.now()
-        
+
         self.create_session(config)
 
         self._state = ReducerState.monitoring

--- a/fedn/fedn/network/controller/control.py
+++ b/fedn/fedn/network/controller/control.py
@@ -99,9 +99,8 @@ class Control(ControlBase):
             return
 
         self._state = ReducerState.instructing
-        config["committed_at"] = datetime.datetime.now().strftime(
-            "%Y-%m-%d %H:%M:%S"
-        )
+        config["committed_at"] = datetime.datetime.now()
+        
         self.create_session(config)
 
         self._state = ReducerState.monitoring


### PR DESCRIPTION
Session - committed_at is now a datetime object, not a string