### PR TITLE
Link to docs tutorial from main readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ Getting started
 
 The best way to get started is to take the quickstart tutorial: 
 
-- `Quickstart PyTorch <https://github.com/scaleoutsystems/fedn/tree/master/examples/mnist-pytorch>`__
+- `Quickstart PyTorch <https://fedn.readthedocs.io/en/latest/quickstart.html>`__
 
 Documentation
 =============
@@ -57,9 +57,9 @@ You will find more details about the architecture, compute package and how to de
 
 FEDn Studio
 ===============
-Scaleout develops a Django Application, FEDn Studio, that provides a UI, authentication/authorization, client identity management, project-based multitenancy for manging multiple projects, and integration with your MLOps pipelines.
-There are also additional tooling and charts for deployments on Kubernetes including integration with several projects from the cloud native landscape. See  `FEDn Framework <https://www.scaleoutsystems.com/framework>`__ 
-for more information. 
+Scaleout also develops FEDn Studio, a web application that extends the FEDn SDK with a UI, production-grade deployment of the FEDn server side on Kubernetes, user authentication/authorization, client identity/API-token management, and project-based multitenancy for segmenting work and resources into collaboration workspaces. FEDn Studio is available as a fully managed service.  
+There is also additional tooling and charts for self-managed deployment on Kubernetes including integration with several projects from the cloud native landscape. 
+See  `FEDn Framework <https://www.scaleoutsystems.com/framework>`__  for more information. 
 
 
 Making contributions

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,12 +3,12 @@
    :caption: Table of Contents
    
    introduction
-   architecture
    quickstart
    apiclient
+   tutorial
+   architecture
    aggregators
    helpers
-   tutorial
    faq
    modules
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -38,7 +38,7 @@ You can verify the deployment using these urls:
        
        $ pip install fedn
        # or from source
-       $ cd fedn
+       $ cd fedn/fedn
        $ pip install . 
 
 Next, we will prepare the client. A key concept in FEDn is the compute package - 
@@ -137,8 +137,16 @@ There is also a Jupyter `Notebook <https://github.com/scaleoutsystems/fedn/blob/
 
 Automate and scale up experimentation with several clients  
 ----------------------------------------------------------
-Now that you have an understanding of the main components of FEDn, you can use the provided docker-compose templates to automate deployment of FEDn and clients. 
-To start the network and attach 4 clients. Standing in ``examples/mnist-pytorch``, run the following docker compose command: 
+You can use the provided docker-compose templates to automate deployment of FEDn and clients. 
+
+Split the dataset in 4 partitions:
+
+.. code-block::
+
+   bin/split_data --num_splits=4 
+
+
+To start 4 clients, standing in ``examples/mnist-pytorch``, run the following docker compose command: 
 
 .. code-block::
 
@@ -170,3 +178,9 @@ You can clean up by running
 
    docker-compose down
 
+Where to go from here? 
+--------
+With you first FEDn federation deployed, we suggest that you take a close look at how a FEDn project is structured
+and how you develop your own compute package:
+
+- Compute package: :ref:`tutorial-label`

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -13,12 +13,15 @@ Prerequisites
 -  `Docker <https://docs.docker.com/get-docker>`__
 -  `Docker Compose <https://docs.docker.com/compose/install>`__
 
+Launch a pseudo-distributed FEDn Network 
+-------------
+
+
 Clone this repository, locate into it and start a pseudo-distributed FEDn network using docker-compose:
 
 .. code-block::
 
    docker-compose up 
-
 
 This starts up the needed backend services MongoDB and Minio, the API Server and one Combiner. 
 You can verify the deployment using these urls: 
@@ -30,6 +33,9 @@ You can verify the deployment using these urls:
 .. warning:: 
    The FEDn network is configured to use a local Minio and MongoDB instances for storage. This is not suitable for production, but is fine for testing.
 
+Install the FEDn SDK
+-------------
+
 .. note::
     To programmatically interact with the FEDn network use the APIClient.
     Install the FEDn via pip:
@@ -40,6 +46,10 @@ You can verify the deployment using these urls:
        # or from source
        $ cd fedn/fedn
        $ pip install . 
+
+
+Prepare the compute package and seed the FEDn network
+-------------
 
 Next, we will prepare the client. A key concept in FEDn is the compute package - 
 a code bundle that contains entrypoints for training and (optionally) validating a model update on the client. 
@@ -68,7 +78,10 @@ Upload the compute package and seed model to FEDn:
    >>> from fedn import APIClient
    >>> client = APIClient(host="localhost", port=8092)
    >>> client.set_package("package.tgz", helper="numpyhelper")
-   >>> client.set_initial_model("seed.npz")      
+   >>> client.set_initial_model("seed.npz")
+
+Configure and attach clients
+-------------
 
 The next step is to configure and attach clients. For this we need to download data and make data partitions: 
 
@@ -117,6 +130,10 @@ To connect a client that uses the data partition ``data/clients/1/mnist.pt`` and
   --network=fedn_default \
   ghcr.io/scaleoutsystems/fedn/fedn:0.8.0-mnist-pytorch run client -in client.yaml --name client1 
 
+
+Start a training session
+-------------
+
 Observe the API Server logs and combiner logs, you should see the client connecting.
 You are now ready to start training the model. In the python enviroment you installed FEDn:
 
@@ -135,7 +152,7 @@ Please see :py:mod:`fedn.network.api` for more details on the APIClient.
 
 There is also a Jupyter `Notebook <https://github.com/scaleoutsystems/fedn/blob/master/examples/mnist-pytorch/API_Example.ipynb>`_ version of this tutorial including examples of how to fetch and visualize model validations.
 
-Automate and scale up experimentation with several clients  
+Automate experimentation with several clients  
 ----------------------------------------------------------
 You can use the provided docker-compose templates to automate deployment of FEDn and clients. 
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1,6 +1,6 @@
 .. _tutorial-label:
 
-Tutorial: Compute Package
+Compute Package
 ================================================
 
 This tutorial walks you through the design of a *compute package* for a FEDn client. The compute package is a tar.gz bundle of the code to be executed by each data-provider/client.

--- a/examples/mnist-pytorch/README.rst
+++ b/examples/mnist-pytorch/README.rst
@@ -21,7 +21,7 @@ Clone this repository, locate into this directory:
 .. code-block::
 
    git clone https://github.com/scaleoutsystems/fedn.git
-   cd fedn/examples/mnist-keras
+   cd fedn/examples/mnist-pytorch
 
 Start a pseudo-distributed FEDn network using docker-compose:
 


### PR DESCRIPTION
## Description

Points the user to the tutorial in the main docs from the root level readme file. 

Also fixes a few typos. 
