### PR TITLE
Bugfix/SK-673 | start_session endpoint should have delete_models=True

### DIFF
--- a/fedn/fedn/network/api/interface.py
+++ b/fedn/fedn/network/api/interface.py
@@ -1011,7 +1011,7 @@ class API:
         rounds=5,
         round_timeout=180,
         round_buffer_size=-1,
-        delete_models=False,
+        delete_models=True,
         validate=True,
         helper="numpyhelper",
         min_clients=1,


### PR DESCRIPTION
delete_models=True is set in APIClient by default but not in the api endpoint. Fixes that.