### PR TITLE
Feature/SK-676 | If no compute package is set when starting a session, Fedn should say so

### DIFF
--- a/fedn/fedn/network/api/interface.py
+++ b/fedn/fedn/network/api/interface.py
@@ -1055,6 +1055,15 @@ class API:
                 {"success": False, "message": "A session is already running."}
             )
 
+        # Check if compute package is set
+        if not self.statestore.get_compute_package():
+            return jsonify(
+                {
+                    "success": False,
+                    "message": "No compute package set. Set compute package before starting session.",
+                }
+            )
+
         # Check that initial (seed) model is set
         if not self.statestore.get_initial_model():
             return jsonify(


### PR DESCRIPTION
Start session - compute package not set error added