### PR TITLE
Feature/SK-697 | Adds token auth to the APIClient

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": true
+        "source.organizeImports": "explicit"
     },
     "python.linting.enabled": true,
     "python.linting.flake8Enabled": true,

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-        "source.organizeImports": "explicit"
+        "source.organizeImports": true
     },
     "python.linting.enabled": true,
     "python.linting.flake8Enabled": true,

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -32,7 +32,7 @@ class APIClient:
         # Override potential env variable if token is passed as argument.
         if not token:
             token = os.environ.get("FEDN_AUTH_TOKEN", False)
-        
+
         if token:
             self.header = {"Authorization": f"{auth_scheme} {token}"}
 

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -19,19 +19,23 @@ class APIClient:
     :type verify: bool
     """
 
-    def __init__(self, host, port=None, secure=False, verify=False, token=None, verbosity="INFO"):
+    def __init__(self, host, port=None, secure=False, verify=False, token=None, auth_scheme=None):
         self.host = host
         self.port = port
         self.secure = secure
         self.verify = verify
         self.header = {}
+        # Auth scheme passed as argument overrides environment variable.
+        # "Token" is the default auth scheme.
+        if not auth_scheme:
+            auth_scheme = os.environ.get("FEDN_AUTH_SCHEME", "Token")
         # Check if auth token is set by environment variable
         env_token = os.environ.get("FEDN_AUTH_TOKEN", False)
         if env_token:
-            self.header = {"Authorization": "Token {}".format(token)}
+            self.header = {"Authorization": f"{auth_scheme} {env_token}"}
         # Override potential env variable if token is passed as argument.
         if token:
-            self.header = {"Authorization": "Token {}".format(token)}
+            self.header = {"Authorization": f"{auth_scheme} {token}"}
 
     def _get_url(self, endpoint):
         if self.secure:

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -3,9 +3,6 @@ import os
 
 import requests
 
-from fedn.common.log_config import (logger, set_log_level_from_string,
-                                    set_log_stream)
-
 __all__ = ['APIClient']
 
 
@@ -35,7 +32,6 @@ class APIClient:
         # Override potential env variable if token is passed as argument.
         if token:
             self.header = {"Authorization": "Token {}".format(token)}
-        set_log_level_from_string(verbosity)
 
     def _get_url(self, endpoint):
         if self.secure:

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -29,11 +29,10 @@ class APIClient:
         # "Token" is the default auth scheme.
         if not auth_scheme:
             auth_scheme = os.environ.get("FEDN_AUTH_SCHEME", "Token")
-        # Check if auth token is set by environment variable
-        env_token = os.environ.get("FEDN_AUTH_TOKEN", False)
-        if env_token:
-            self.header = {"Authorization": f"{auth_scheme} {env_token}"}
         # Override potential env variable if token is passed as argument.
+        if not token:
+            token = os.environ.get("FEDN_AUTH_TOKEN", False)
+        
         if token:
             self.header = {"Authorization": f"{auth_scheme} {token}"}
 

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -26,7 +26,7 @@ class APIClient:
         self.verify = verify
         self.header = {}
         # Check if auth token is set by environment variable
-        env_token = os.environ("FEDN_AUTH_TOKEN", False)
+        env_token = os.environ.get("FEDN_AUTH_TOKEN", False)
         if env_token:
             self.header = {"Authorization": "Token {}".format(token)}
         # Override potential env variable if token is passed as argument.


### PR DESCRIPTION
## Description
Adds the option to pass an auth token when initializing the APIClient (either as input to the constructor or by setting the environment variable FEDN_AUTH_TOKEN).

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->