### PR TITLE
Feature/SK-710 | FEDn cli - init server

### DIFF
--- a/examples/mnist-pytorch/client/entrypoint
+++ b/examples/mnist-pytorch/client/entrypoint
@@ -3,7 +3,6 @@ import collections
 import math
 import os
 
-import docker
 import fire
 import torch
 
@@ -18,12 +17,12 @@ NUM_CLASSES = 10
 def _get_data_path():
     """ For test automation using docker-compose. """
     # Figure out FEDn client number from container name
-    client = docker.from_env()
-    container = client.containers.get(os.environ['HOSTNAME'])
-    number = container.name[-1]
+    # client = docker.from_env()
+    # container = client.containers.get(os.environ['HOSTNAME'])
+    # number = container.name[-1]
 
     # Return data path
-    return f"/var/data/clients/{number}/mnist.pt"
+    return f"/home/nicklas/repos/fedn/examples/mnist-pytorch/data/clients/1/mnist.pt"
 
 
 def compile_model():

--- a/examples/mnist-pytorch/client/fedn.yaml
+++ b/examples/mnist-pytorch/client/fedn.yaml
@@ -1,5 +1,5 @@
 entry_points:
   train:
-    command: /venv/bin/python entrypoint train $ENTRYPOINT_OPTS
+    command: /home/nicklas/repos/fedn/examples/mnist-pytorch/.mnist-pytorch/bin/python entrypoint train $ENTRYPOINT_OPTS
   validate:
-    command: /venv/bin/python entrypoint validate $ENTRYPOINT_OPTS
+    command: /home/nicklas/repos/fedn/examples/mnist-pytorch/.mnist-pytorch/bin/python entrypoint validate $ENTRYPOINT_OPTS

--- a/fedn/cli/__init__.py
+++ b/fedn/cli/__init__.py
@@ -1,2 +1,3 @@
+from .list_cmd import list_cmd  # noqa: F401
 from .main import main  # noqa: F401
 from .run_cmd import run_cmd  # noqa: F401

--- a/fedn/cli/__init__.py
+++ b/fedn/cli/__init__.py
@@ -1,3 +1,4 @@
 from .list_cmd import list_cmd  # noqa: F401
 from .main import main  # noqa: F401
 from .run_cmd import run_cmd  # noqa: F401
+from .upload_cmd import upload_cmd  # noqa: F401

--- a/fedn/cli/__init__.py
+++ b/fedn/cli/__init__.py
@@ -1,3 +1,4 @@
+from .config_cmd import config_cmd  # noqa: F401
 from .list_cmd import list_cmd  # noqa: F401
 from .main import main  # noqa: F401
 from .run_cmd import run_cmd  # noqa: F401

--- a/fedn/cli/__init__.py
+++ b/fedn/cli/__init__.py
@@ -1,4 +1,5 @@
 from .list_cmd import list_cmd  # noqa: F401
 from .main import main  # noqa: F401
 from .run_cmd import run_cmd  # noqa: F401
+from .start_cmd import start_cmd  # noqa: F401
 from .upload_cmd import upload_cmd  # noqa: F401

--- a/fedn/cli/config_cmd.py
+++ b/fedn/cli/config_cmd.py
@@ -1,0 +1,71 @@
+import os
+
+import click
+
+from .main import main
+
+
+@main.group('config', invoke_without_command=True)
+@click.pass_context
+def config_cmd(ctx):
+    """
+    :param ctx:
+    """
+    if ctx.invoked_subcommand is None:
+        _protocol = os.environ.get('FEDN_PROTOCOL')
+        _host = os.environ.get('FEDN_HOST')
+        _port = os.environ.get('FEDN_PORT')
+        _token = os.environ.get("FEDN_TOKEN")
+        _scheme = os.environ.get("FEDN_AUTH_SCHEME")
+
+        click.echo('\n--- FEDn Cli Configuration ---\n')
+        click.echo('Current configuration:\n')
+
+        click.echo(f'FEDN_PROTOCOL: {_protocol or "Not set"}')
+        click.echo(f'FEDN_HOST: {_host or "Not set"}')
+        click.echo(f'FEDN_PORT: {_port or "Not set"}')
+        click.echo(f'FEDN_TOKEN: {_token or "Not set"}')
+        click.echo(f'FEDN_AUTH_SCHEME: {_scheme or "Not set"}\n')
+
+
+@config_cmd.command('set')
+@click.option('--protocol', prompt="Protocol", default=lambda: os.environ.get("FEDN_PROTOCOL", ""))
+@click.option('--host', prompt="Host", default=lambda: os.environ.get("FEDN_HOST", ""))
+@click.option('--port', prompt="Port", default=lambda: os.environ.get("FEDN_PORT", ""))
+@click.option('--token', prompt="Token", default=lambda: os.environ.get("FEDN_TOKEN", ""))
+@click.option('--scheme', prompt="Scheme", default=lambda: os.environ.get("FEDN_AUTH_SCHEME", ""))
+def set_config(protocol: str, host: str, port: int, token: str, scheme: str):
+    """
+    - Get configuration script from user input that can be used to set environment variables.
+    return: None
+    """
+    click.echo("\n-------------------\n")
+
+    if protocol:
+        click.echo(f"\nexport FEDN_PROTOCOL={protocol}")
+
+    if host:
+        click.echo(f"export FEDN_HOST={host}")
+
+    if port:
+        click.echo(f"export FEDN_PORT={port}")
+
+    if token:
+        click.echo(f"export FEDN_TOKEN={token}")
+
+    if scheme:
+        click.echo(f"export FEDN_AUTH_SCHEME={scheme}")
+
+
+@config_cmd.command('clear')
+def clear_config():
+    """
+    - Get configuration script from user input that can be used to remove environment variables.
+    return: None
+    """
+    click.echo("\n-------------------\n")
+    click.echo("unset FEDN_PROTOCOL")
+    click.echo("unset FEDN_HOST")
+    click.echo("unset FEDN_PORT")
+    click.echo("unset FEDN_TOKEN")
+    click.echo("unset FEDN_AUTH_SCHEME")

--- a/fedn/cli/config_cmd.py
+++ b/fedn/cli/config_cmd.py
@@ -18,7 +18,7 @@ envs = [
 @click.pass_context
 def config_cmd(ctx):
     """
-    :param ctx:
+    - Configuration commands for the FEDn CLI.
     """
     if ctx.invoked_subcommand is None:
         click.echo('\n--- FEDn Cli Configuration ---\n')
@@ -72,7 +72,6 @@ def clear_config():
     os_name = sys.platform
 
     if os_name == 'win32':
-
         for env in envs:
             click.echo(f"set {env}=;")
     else:

--- a/fedn/cli/config_cmd.py
+++ b/fedn/cli/config_cmd.py
@@ -10,7 +10,9 @@ envs = [
     "FEDN_HOST",
     "FEDN_PORT",
     "FEDN_TOKEN",
-    "FEDN_AUTH_SCHEME"
+    "FEDN_AUTH_SCHEME",
+    "FEDN_CONTROLLER_URL",
+    "FEDN_PACKAGE_PATH"
 ]
 
 

--- a/fedn/cli/config_cmd.py
+++ b/fedn/cli/config_cmd.py
@@ -12,7 +12,7 @@ envs = [
     "FEDN_TOKEN",
     "FEDN_AUTH_SCHEME",
     "FEDN_CONTROLLER_URL",
-    "FEDN_PACKAGE_PATH"
+    "FEDN_PACKAGE_DIR"
 ]
 
 

--- a/fedn/cli/list_cmd.py
+++ b/fedn/cli/list_cmd.py
@@ -75,7 +75,7 @@ def list_clients(ctx, protocol: str, host: str, port: str, token: str = None, n_
         response = requests.get(url, headers=headers)
         print_response(response, 'clients')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')
 
 
 @click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
@@ -109,7 +109,7 @@ def list_combiners(ctx, protocol: str, host: str, port: str, token: str = None, 
         response = requests.get(url, headers=headers)
         print_response(response, 'combiners')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')
 
 
 @click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
@@ -143,7 +143,7 @@ def list_models(ctx, protocol: str, host: str, port: str, token: str = None, n_m
         response = requests.get(url, headers=headers)
         print_response(response, 'models')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')
 
 
 @click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
@@ -177,7 +177,7 @@ def list_packages(ctx, protocol: str, host: str, port: str, token: str = None, n
         response = requests.get(url, headers=headers)
         print_response(response, 'packages')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')
 
 
 @click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
@@ -211,7 +211,7 @@ def list_rounds(ctx, protocol: str, host: str, port: str, token: str = None, n_m
         response = requests.get(url, headers=headers)
         print_response(response, 'rounds')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')
 
 
 @click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
@@ -245,7 +245,7 @@ def list_sessions(ctx, protocol: str, host: str, port: str, token: str = None, n
         response = requests.get(url, headers=headers)
         print_response(response, 'sessions')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')
 
 
 @click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
@@ -279,7 +279,7 @@ def list_statuses(ctx, protocol: str, host: str, port: str, token: str = None, n
         response = requests.get(url, headers=headers)
         print_response(response, 'statuses')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')
 
 
 @click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
@@ -313,4 +313,4 @@ def list_validations(ctx, protocol: str, host: str, port: str, token: str = None
         response = requests.get(url, headers=headers)
         print_response(response, 'validations')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')

--- a/fedn/cli/list_cmd.py
+++ b/fedn/cli/list_cmd.py
@@ -9,8 +9,14 @@ from .shared import API_VERSION, CONTROLLER_DEFAULTS
 
 def print_response(response, entity_name: str):
     """
+    Prints the api response to the cli.
     :param response:
-    :return:
+        type: array
+        description: list of entities
+    :param entity_name:
+        type: string
+        description: name of entity
+    return: None
     """
     if response.status_code == 200:
         json_data = response.json()

--- a/fedn/cli/list_cmd.py
+++ b/fedn/cli/list_cmd.py
@@ -1,0 +1,21 @@
+
+import click
+
+from .main import main
+
+
+@main.group('list')
+@click.pass_context
+def list_cmd(ctx):
+    """
+    :param ctx:
+    """
+    pass
+
+
+@list_cmd.command('models')
+def list_models():
+    """
+    :return:
+    """
+    click.echo('Listing models')

--- a/fedn/cli/list_cmd.py
+++ b/fedn/cli/list_cmd.py
@@ -4,7 +4,7 @@ import click
 import requests
 
 from .main import main
-from .shared import API_VERSION, CONTROLLER_DEFAULTS, get_api_url, get_token
+from .shared import CONTROLLER_DEFAULTS, get_api_url, get_token
 
 
 def print_response(response, entity_name: str):

--- a/fedn/cli/list_cmd.py
+++ b/fedn/cli/list_cmd.py
@@ -4,7 +4,7 @@ import click
 import requests
 
 from .main import main
-from .shared import API_VERSION, CONTROLLER_DEFAULTS
+from .shared import API_VERSION, CONTROLLER_DEFAULTS, get_api_url, get_token
 
 
 def print_response(response, entity_name: str):
@@ -44,24 +44,32 @@ def list_cmd(ctx):
     pass
 
 
-@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('--n_max', required=False, help='Number of items to list.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('--n_max', required=False, help='Number of items to list')
 @list_cmd.command('clients')
 @click.pass_context
-def list_clients(ctx, host, port, n_max):
+def list_clients(ctx, protocol: str, host: str, port: str, token: str = None, n_max: int = None):
     """
     return:
     - count: number of clients
     - result: list of clients
     """
-    url = f'http://{host}:{port}/api/{API_VERSION}/clients'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint='clients')
     headers = {}
 
     if n_max:
         headers['X-Limit'] = n_max
 
+    _token = get_token(token)
+
+    if _token:
+        headers['Authorization'] = _token
+
     click.echo(f'\nListing clients: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         response = requests.get(url, headers=headers)
@@ -70,24 +78,32 @@ def list_clients(ctx, host, port, n_max):
         click.echo(f'Error: Could not connect to {host}:{port}')
 
 
-@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('--n_max', required=False, help='Number of items to list.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('--n_max', required=False, help='Number of items to list')
 @list_cmd.command('combiners')
 @click.pass_context
-def list_combiners(ctx, host, port, n_max):
+def list_combiners(ctx, protocol: str, host: str, port: str, token: str = None, n_max: int = None):
     """
     return:
     - count: number of combiners
     - result: list of combiners
     """
-    url = f'http://{host}:{port}/api/{API_VERSION}/combiners'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint='combiners')
     headers = {}
 
     if n_max:
         headers['X-Limit'] = n_max
 
+    _token = get_token(token)
+
+    if _token:
+        headers['Authorization'] = _token
+
     click.echo(f'\nListing combiners: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         response = requests.get(url, headers=headers)
@@ -96,24 +112,32 @@ def list_combiners(ctx, host, port, n_max):
         click.echo(f'Error: Could not connect to {host}:{port}')
 
 
-@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('--n_max', required=False, help='Number of items to list.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('--n_max', required=False, help='Number of items to list')
 @list_cmd.command('models')
 @click.pass_context
-def list_models(ctx, host, port, n_max):
+def list_models(ctx, protocol: str, host: str, port: str, token: str = None, n_max: int = None):
     """
     return:
     - count: number of models
     - result: list of models
     """
-    url = f'http://{host}:{port}/api/{API_VERSION}/models'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint='models')
     headers = {}
 
     if n_max:
         headers['X-Limit'] = n_max
 
+    _token = get_token(token)
+
+    if _token:
+        headers['Authorization'] = _token
+
     click.echo(f'\nListing models: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         response = requests.get(url, headers=headers)
@@ -122,24 +146,32 @@ def list_models(ctx, host, port, n_max):
         click.echo(f'Error: Could not connect to {host}:{port}')
 
 
-@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('--n_max', required=False, help='Number of items to list.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('--n_max', required=False, help='Number of items to list')
 @list_cmd.command('packages')
 @click.pass_context
-def list_packages(ctx, host, port, n_max):
+def list_packages(ctx, protocol: str, host: str, port: str, token: str = None, n_max: int = None):
     """
     return:
     - count: number of packages
     - result: list of packages
     """
-    url = f'http://{host}:{port}/api/{API_VERSION}/packages'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint='packages')
     headers = {}
 
     if n_max:
         headers['X-Limit'] = n_max
 
+    _token = get_token(token)
+
+    if _token:
+        headers['Authorization'] = _token
+
     click.echo(f'\nListing packages: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         response = requests.get(url, headers=headers)
@@ -148,24 +180,32 @@ def list_packages(ctx, host, port, n_max):
         click.echo(f'Error: Could not connect to {host}:{port}')
 
 
-@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('--n_max', required=False, help='Number of items to list.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('--n_max', required=False, help='Number of items to list')
 @list_cmd.command('rounds')
 @click.pass_context
-def list_rounds(ctx, host, port, n_max):
+def list_rounds(ctx, protocol: str, host: str, port: str, token: str = None, n_max: int = None):
     """
     return:
     - count: number of rounds
     - result: list of rounds
     """
-    url = f'http://{host}:{port}/api/{API_VERSION}/rounds'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint='rounds')
     headers = {}
 
     if n_max:
         headers['X-Limit'] = n_max
 
+    _token = get_token(token)
+
+    if _token:
+        headers['Authorization'] = _token
+
     click.echo(f'\nListing rounds: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         response = requests.get(url, headers=headers)
@@ -174,24 +214,32 @@ def list_rounds(ctx, host, port, n_max):
         click.echo(f'Error: Could not connect to {host}:{port}')
 
 
-@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('--n_max', required=False, help='Number of items to list.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('--n_max', required=False, help='Number of items to list')
 @list_cmd.command('sessions')
 @click.pass_context
-def list_sessions(ctx, host, port, n_max):
+def list_sessions(ctx, protocol: str, host: str, port: str, token: str = None, n_max: int = None):
     """
     return:
     - count: number of sessions
     - result: list of sessions
     """
-    url = f'http://{host}:{port}/api/{API_VERSION}/sessions'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint='sessions')
     headers = {}
 
     if n_max:
         headers['X-Limit'] = n_max
 
+    _token = get_token(token)
+
+    if _token:
+        headers['Authorization'] = _token
+
     click.echo(f'\nListing sessions: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         response = requests.get(url, headers=headers)
@@ -200,24 +248,32 @@ def list_sessions(ctx, host, port, n_max):
         click.echo(f'Error: Could not connect to {host}:{port}')
 
 
-@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('--n_max', required=False, help='Number of items to list.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('--n_max', required=False, help='Number of items to list')
 @list_cmd.command('statuses')
 @click.pass_context
-def list_statuses(ctx, host, port, n_max):
+def list_statuses(ctx, protocol: str, host: str, port: str, token: str = None, n_max: int = None):
     """
     return:
     - count: number of statuses
     - result: list of statuses
     """
-    url = f'http://{host}:{port}/api/{API_VERSION}/statuses'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint='statuses')
     headers = {}
 
     if n_max:
         headers['X-Limit'] = n_max
 
+    _token = get_token(token)
+
+    if _token:
+        headers['Authorization'] = _token
+
     click.echo(f'\nListing statuses: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         response = requests.get(url, headers=headers)
@@ -226,24 +282,32 @@ def list_statuses(ctx, host, port, n_max):
         click.echo(f'Error: Could not connect to {host}:{port}')
 
 
-@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('--n_max', required=False, help='Number of items to list.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('--n_max', required=False, help='Number of items to list')
 @list_cmd.command('validations')
 @click.pass_context
-def list_validations(ctx, host, port, n_max):
+def list_validations(ctx, protocol: str, host: str, port: str, token: str = None, n_max: int = None):
     """
     return:
     - count: number of validations
     - result: list of validations
     """
-    url = f'http://{host}:{port}/api/{API_VERSION}/validations'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint='validations')
     headers = {}
 
     if n_max:
         headers['X-Limit'] = n_max
 
+    _token = get_token(token)
+
+    if _token:
+        headers['Authorization'] = _token
+
     click.echo(f'\nListing validations: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         response = requests.get(url, headers=headers)

--- a/fedn/cli/list_cmd.py
+++ b/fedn/cli/list_cmd.py
@@ -1,8 +1,32 @@
 
+
 import click
+import requests
 
 from .main import main
+from .shared import API_VERSION, CONTROLLER_DEFAULTS
 
+
+def print_response(response, entity_name: str):
+    """
+    :param response:
+    :return:
+    """
+    if response.status_code == 200:
+        json_data = response.json()
+        count, result = json_data.values()
+        click.echo(f'Found {count} {entity_name}')
+        click.echo('\n---------------------------------\n')
+        for obj in result:
+            click.echo('{')
+            for k, v in obj.items():
+                click.echo(f'\t{k}: {v}')
+            click.echo('}')
+    elif response.status_code == 500:
+        json_data = response.json()
+        click.echo(f'Error: {json_data["message"]}')
+    else:
+        click.echo(f'Error: {response.status_code}')
 
 @main.group('list')
 @click.pass_context
@@ -13,9 +37,23 @@ def list_cmd(ctx):
     pass
 
 
+@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('--n_max', required=False, help='Number of items to list.')
 @list_cmd.command('models')
-def list_models():
+@click.pass_context
+def list_models(ctx, host, port, n_max):
     """
     :return:
     """
-    click.echo('Listing models')
+    url = f'http://{host}:{port}/api/{API_VERSION}/models'
+    headers = {}
+
+    if n_max:
+        headers['X-Limit'] = n_max
+
+    click.echo(f'\nListing models: {url}\n')
+
+    response = requests.get(url, headers=headers)
+
+    print_response(response, 'models')

--- a/fedn/cli/list_cmd.py
+++ b/fedn/cli/list_cmd.py
@@ -39,7 +39,7 @@ def print_response(response, entity_name: str):
 @click.pass_context
 def list_cmd(ctx):
     """
-    :param ctx:
+    - List entities from the api.
     """
     pass
 

--- a/fedn/cli/list_cmd.py
+++ b/fedn/cli/list_cmd.py
@@ -28,6 +28,7 @@ def print_response(response, entity_name: str):
     else:
         click.echo(f'Error: {response.status_code}')
 
+
 @main.group('list')
 @click.pass_context
 def list_cmd(ctx):
@@ -40,11 +41,65 @@ def list_cmd(ctx):
 @click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
 @click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
 @click.option('--n_max', required=False, help='Number of items to list.')
+@list_cmd.command('clients')
+@click.pass_context
+def list_clients(ctx, host, port, n_max):
+    """
+    return:
+    - count: number of clients
+    - result: list of clients
+    """
+    url = f'http://{host}:{port}/api/{API_VERSION}/clients'
+    headers = {}
+
+    if n_max:
+        headers['X-Limit'] = n_max
+
+    click.echo(f'\nListing clients: {url}\n')
+
+    try:
+        response = requests.get(url, headers=headers)
+        print_response(response, 'clients')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')
+
+
+@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('--n_max', required=False, help='Number of items to list.')
+@list_cmd.command('combiners')
+@click.pass_context
+def list_combiners(ctx, host, port, n_max):
+    """
+    return:
+    - count: number of combiners
+    - result: list of combiners
+    """
+    url = f'http://{host}:{port}/api/{API_VERSION}/combiners'
+    headers = {}
+
+    if n_max:
+        headers['X-Limit'] = n_max
+
+    click.echo(f'\nListing combiners: {url}\n')
+
+    try:
+        response = requests.get(url, headers=headers)
+        print_response(response, 'combiners')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')
+
+
+@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('--n_max', required=False, help='Number of items to list.')
 @list_cmd.command('models')
 @click.pass_context
 def list_models(ctx, host, port, n_max):
     """
-    :return:
+    return:
+    - count: number of models
+    - result: list of models
     """
     url = f'http://{host}:{port}/api/{API_VERSION}/models'
     headers = {}
@@ -54,6 +109,138 @@ def list_models(ctx, host, port, n_max):
 
     click.echo(f'\nListing models: {url}\n')
 
-    response = requests.get(url, headers=headers)
+    try:
+        response = requests.get(url, headers=headers)
+        print_response(response, 'models')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')
 
-    print_response(response, 'models')
+
+@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('--n_max', required=False, help='Number of items to list.')
+@list_cmd.command('packages')
+@click.pass_context
+def list_packages(ctx, host, port, n_max):
+    """
+    return:
+    - count: number of packages
+    - result: list of packages
+    """
+    url = f'http://{host}:{port}/api/{API_VERSION}/packages'
+    headers = {}
+
+    if n_max:
+        headers['X-Limit'] = n_max
+
+    click.echo(f'\nListing packages: {url}\n')
+
+    try:
+        response = requests.get(url, headers=headers)
+        print_response(response, 'packages')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')
+
+
+@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('--n_max', required=False, help='Number of items to list.')
+@list_cmd.command('rounds')
+@click.pass_context
+def list_rounds(ctx, host, port, n_max):
+    """
+    return:
+    - count: number of rounds
+    - result: list of rounds
+    """
+    url = f'http://{host}:{port}/api/{API_VERSION}/rounds'
+    headers = {}
+
+    if n_max:
+        headers['X-Limit'] = n_max
+
+    click.echo(f'\nListing rounds: {url}\n')
+
+    try:
+        response = requests.get(url, headers=headers)
+        print_response(response, 'rounds')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')
+
+
+@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('--n_max', required=False, help='Number of items to list.')
+@list_cmd.command('sessions')
+@click.pass_context
+def list_sessions(ctx, host, port, n_max):
+    """
+    return:
+    - count: number of sessions
+    - result: list of sessions
+    """
+    url = f'http://{host}:{port}/api/{API_VERSION}/sessions'
+    headers = {}
+
+    if n_max:
+        headers['X-Limit'] = n_max
+
+    click.echo(f'\nListing sessions: {url}\n')
+
+    try:
+        response = requests.get(url, headers=headers)
+        print_response(response, 'sessions')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')
+
+
+@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('--n_max', required=False, help='Number of items to list.')
+@list_cmd.command('statuses')
+@click.pass_context
+def list_statuses(ctx, host, port, n_max):
+    """
+    return:
+    - count: number of statuses
+    - result: list of statuses
+    """
+    url = f'http://{host}:{port}/api/{API_VERSION}/statuses'
+    headers = {}
+
+    if n_max:
+        headers['X-Limit'] = n_max
+
+    click.echo(f'\nListing statuses: {url}\n')
+
+    try:
+        response = requests.get(url, headers=headers)
+        print_response(response, 'statuses')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')
+
+
+@click.option('-h', '--host', required=False, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=False, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('--n_max', required=False, help='Number of items to list.')
+@list_cmd.command('validations')
+@click.pass_context
+def list_validations(ctx, host, port, n_max):
+    """
+    return:
+    - count: number of validations
+    - result: list of validations
+    """
+    url = f'http://{host}:{port}/api/{API_VERSION}/validations'
+    headers = {}
+
+    if n_max:
+        headers['X-Limit'] = n_max
+
+    click.echo(f'\nListing validations: {url}\n')
+
+    try:
+        response = requests.get(url, headers=headers)
+        print_response(response, 'validations')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')

--- a/fedn/cli/main.py
+++ b/fedn/cli/main.py
@@ -10,7 +10,6 @@ CONTEXT_SETTINGS = dict(
 @click.pass_context
 def main(ctx):
     """
-
-    :param ctx:
+    *** FEDn CLI ***
     """
     ctx.obj = dict()

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -75,8 +75,7 @@ def validate_client_config(config):
 @click.pass_context
 def run_cmd(ctx):
     """
-
-    :param ctx:
+    - Run FEDn apps (client, combiner, controller).
     """
     if ctx.invoked_subcommand is None:
         click.echo('Running FEDn...')

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -161,14 +161,23 @@ def combiner_cmd(ctx, discoverhost, discoverport, token, name, host, port, fqdn,
 
     :param ctx:
     :param discoverhost:
+        type: str
     :param discoverport:
+        type: int
     :param token:
+        type: str
     :param name:
+        type: str
     :param hostname:
+        type: str
     :param port:
+        type: int
     :param secure:
+        type: bool
     :param max_clients:
+        type: int
     :param init:
+        type: str (path to file with configuration settings for combiner)
     """
     config = {'discover_host': discoverhost, 'discover_port': discoverport, 'token': token, 'host': host,
               'port': port, 'fqdn': fqdn, 'name': name, 'secure': secure, 'verify': verify, 'max_clients': max_clients,
@@ -176,6 +185,8 @@ def combiner_cmd(ctx, discoverhost, discoverport, token, name, host, port, fqdn,
 
     if config['init']:
         apply_config(config)
+
+    click.echo(f"Starting combiner on {host}:{port}")
 
     combiner = Combiner(config)
     combiner.run()
@@ -205,6 +216,8 @@ def controller_cmd(ctx, host, port, debug, init):
 
     if config['init']:
         apply_config(config)
+
+    click.echo(f"Starting API server on {host}:{port}")
 
     from fedn.network.api.server import start_api
 

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -69,14 +69,15 @@ def validate_client_config(config):
         raise InvalidClientConfig("Could not load config from file. Check config")
 
 
-@main.group('run')
+@main.group('run', invoke_without_command=True)
 @click.pass_context
 def run_cmd(ctx):
     """
 
     :param ctx:
     """
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo('Running FEDn...')
 
 
 @run_cmd.command('client')
@@ -193,7 +194,7 @@ def combiner_cmd(ctx, discoverhost, discoverport, token, name, host, port, fqdn,
 
 
 @run_cmd.command('controller')
-@click.option('-h', '--host', required=False, default="api-server", help='Set hostname.')
+@click.option('-h', '--host', required=False, default="localhost", help='Set hostname.')
 @click.option('-i', '--port', required=False, default=8092, help='Set port.')
 @click.option('--debug', required=False, default=False, help='Set debug.')
 @click.option('-in', '--init', required=False, default=None,

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -87,9 +87,19 @@ def run_cmd(ctx):
         thread_api = threading.Thread(target=start_api, args=(config,))
         thread_api.start()
 
-        config = {'discover_host': COMBINER_DEFAULTS['discover_host'], 'discover_port': COMBINER_DEFAULTS['discover_port'], 'token': None, 'host': COMBINER_DEFAULTS['host'],
-              'port': COMBINER_DEFAULTS['port'], 'fqdn': None, 'name': COMBINER_DEFAULTS['name'], 'secure': False, 'verify': False, 'max_clients': COMBINER_DEFAULTS['max_clients'],
-              'init': None}
+        config = {
+            'discover_host': COMBINER_DEFAULTS['discover_host'],
+            'discover_port': COMBINER_DEFAULTS['discover_port'],
+            'token': None,
+            'host': COMBINER_DEFAULTS['host'],
+            'port': COMBINER_DEFAULTS['port'],
+            'fqdn': None,
+            'name': COMBINER_DEFAULTS['name'],
+            'secure': False,
+            'verify': False,
+            'max_clients': COMBINER_DEFAULTS['max_clients'],
+            'init': None
+        }
 
         click.echo(f"Starting combiner on {config['host']}:{config['port']}")
 

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -179,3 +179,33 @@ def combiner_cmd(ctx, discoverhost, discoverport, token, name, host, port, fqdn,
 
     combiner = Combiner(config)
     combiner.run()
+
+
+@run_cmd.command('controller')
+@click.option('-h', '--host', required=False, default="api-server", help='Set hostname.')
+@click.option('-i', '--port', required=False, default=8092, help='Set port.')
+@click.option('--debug', required=False, default=False, help='Set debug.')
+@click.option('-in', '--init', required=False, default=None,
+              help='Path to configuration file to (re)init controller.')
+@click.pass_context
+def controller_cmd(ctx, host, port, debug, init):
+    """
+
+    :param ctx:
+    :param host:
+        type: str
+    :param port:
+        type: int
+    :param debug:
+        type: bool
+    :param init:
+        type: str (path to file with configuration settings for controller)
+    """
+    config = {'host': host, 'port': port, 'debug': debug, 'init': init}
+
+    if config['init']:
+        apply_config(config)
+
+    from fedn.network.api.server import start_api
+
+    start_api(config)

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -10,7 +10,7 @@ from fedn.network.clients.client import Client
 from fedn.network.combiner.combiner import Combiner
 
 from .main import main
-from .shared import CLIENT_DEFAULTS, COMBINER_DEFAULTS, CONTROLLER_DEFAULTS
+from .shared import CLIENT_DEFAULTS, COMBINER_DEFAULTS, CONTROLLER_DEFAULTS, get_client_package_path
 
 
 def get_statestore_config_from_file(init):
@@ -118,6 +118,7 @@ def run_cmd(ctx):
 @click.option('-n', '--name', required=False, default="client" + str(uuid.uuid4())[:8])
 @click.option('-i', '--client_id', required=False)
 @click.option('--local-package', is_flag=True, help='Enable local compute package')
+@click.option('-pp', '--package-path', required=False, help='Path to local package')
 @click.option('--force-ssl', is_flag=True, help='Force SSL/TLS for REST service')
 @click.option('-u', '--dry-run', required=False, default=False)
 @click.option('-s', '--secure', required=False, default=False)
@@ -134,7 +135,7 @@ def run_cmd(ctx):
 @click.option('--reconnect-after-missed-heartbeat', required=False, default=30)
 @click.option('--verbosity', required=False, default='INFO', type=click.Choice(['CRITICAL', 'ERROR', 'WARNING', 'INFO', 'DEBUG'], case_sensitive=False))
 @click.pass_context
-def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, local_package, force_ssl, dry_run, secure, preshared_cert,
+def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, local_package, package_path, force_ssl, dry_run, secure, preshared_cert,
                verify, preferred_combiner, validator, trainer, init, logfile, heartbeat_interval, reconnect_after_missed_heartbeat,
                verbosity):
     """
@@ -159,11 +160,14 @@ def client_cmd(ctx, discoverhost, discoverport, token, name, client_id, local_pa
     :return:
     """
     remote = False if local_package else True
+
+    package_path = get_client_package_path(package_path)
+
     config = {'discover_host': discoverhost, 'discover_port': discoverport, 'token': token, 'name': name,
               'client_id': client_id, 'remote_compute_context': remote, 'force_ssl': force_ssl, 'dry_run': dry_run, 'secure': secure,
               'preshared_cert': preshared_cert, 'verify': verify, 'preferred_combiner': preferred_combiner,
               'validator': validator, 'trainer': trainer, 'init': init, 'logfile': logfile, 'heartbeat_interval': heartbeat_interval,
-              'reconnect_after_missed_heartbeat': reconnect_after_missed_heartbeat, 'verbosity': verbosity}
+              'reconnect_after_missed_heartbeat': reconnect_after_missed_heartbeat, 'verbosity': verbosity, 'package_path': package_path}
 
     if init:
         apply_config(config)

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -10,26 +10,7 @@ from fedn.network.clients.client import Client
 from fedn.network.combiner.combiner import Combiner
 
 from .main import main
-
-CONTROLLER_DEFAULTS = {
-    'host': 'localhost',
-    'port': 8092,
-    'debug': False
-}
-
-COMBINER_DEFAULTS = {
-    'discover_host': 'localhost',
-    'discover_port': 8092,
-    'host': 'localhost',
-    'port': 12080,
-    "name": "combiner",
-    "max_clients": 30
-}
-
-CLIENT_DEFAULTS = {
-    'discover_host': 'localhost',
-    'discover_port': 8092,
-}
+from .shared import CLIENT_DEFAULTS, COMBINER_DEFAULTS, CONTROLLER_DEFAULTS
 
 
 def get_statestore_config_from_file(init):

--- a/fedn/cli/run_cmd.py
+++ b/fedn/cli/run_cmd.py
@@ -88,7 +88,7 @@ def run_cmd(ctx):
         thread_api = threading.Thread(target=start_api, args=(config,))
         thread_api.start()
 
-        config = {'discover_host': COMBINER_DEFAULTS['discover_host'], 'discover_port': COMBINER_DEFAULTS['port'], 'token': None, 'host': COMBINER_DEFAULTS['host'],
+        config = {'discover_host': COMBINER_DEFAULTS['discover_host'], 'discover_port': COMBINER_DEFAULTS['discover_port'], 'token': None, 'host': COMBINER_DEFAULTS['host'],
               'port': COMBINER_DEFAULTS['port'], 'fqdn': None, 'name': COMBINER_DEFAULTS['name'], 'secure': False, 'verify': False, 'max_clients': COMBINER_DEFAULTS['max_clients'],
               'init': None}
 

--- a/fedn/cli/shared.py
+++ b/fedn/cli/shared.py
@@ -48,5 +48,5 @@ def get_token(token: str) -> str:
     return f"{scheme} {_token}"
 
 
-def get_client_package_path(path: str) -> str:
-    return path or os.environ.get('FEDN_PACKAGE_PATH', None)
+def get_client_package_dir(path: str) -> str:
+    return path or os.environ.get('FEDN_PACKAGE_DIR', None)

--- a/fedn/cli/shared.py
+++ b/fedn/cli/shared.py
@@ -25,6 +25,11 @@ API_VERSION = 'v1'
 
 
 def get_api_url(protocol: str, host: str, port: str, endpoint: str) -> str:
+    _url = os.environ.get('FEDN_CONTROLLER_URL')
+
+    if _url:
+        return f'{_url}/api/{API_VERSION}/{endpoint}'
+
     _protocol = os.environ.get('FEDN_PROTOCOL') or protocol or CONTROLLER_DEFAULTS['protocol']
     _host = os.environ.get('FEDN_HOST') or host or CONTROLLER_DEFAULTS['host']
     _port = os.environ.get('FEDN_PORT') or port or CONTROLLER_DEFAULTS['port']

--- a/fedn/cli/shared.py
+++ b/fedn/cli/shared.py
@@ -1,4 +1,7 @@
+import os
+
 CONTROLLER_DEFAULTS = {
+    'protocol': 'http',
     'host': 'localhost',
     'port': 8092,
     'debug': False
@@ -19,3 +22,22 @@ CLIENT_DEFAULTS = {
 }
 
 API_VERSION = 'v1'
+
+
+def get_api_url(protocol: str, host: str, port: str, endpoint: str) -> str:
+    _protocol = os.environ.get('FEDN_PROTOCOL') or protocol or CONTROLLER_DEFAULTS['protocol']
+    _host = os.environ.get('FEDN_HOST') or host or CONTROLLER_DEFAULTS['host']
+    _port = os.environ.get('FEDN_PORT') or port or CONTROLLER_DEFAULTS['port']
+
+    return f'{_protocol}://{_host}:{_port}/api/{API_VERSION}/{endpoint}'
+
+
+def get_token(token: str) -> str:
+    _token = os.environ.get("FEDN_TOKEN", token)
+
+    if _token is None:
+        return None
+
+    scheme = os.environ.get("FEDN_AUTH_SCHEME", "Bearer")
+
+    return f"{scheme} {_token}"

--- a/fedn/cli/shared.py
+++ b/fedn/cli/shared.py
@@ -1,0 +1,21 @@
+CONTROLLER_DEFAULTS = {
+    'host': 'localhost',
+    'port': 8092,
+    'debug': False
+}
+
+COMBINER_DEFAULTS = {
+    'discover_host': 'localhost',
+    'discover_port': 8092,
+    'host': 'localhost',
+    'port': 12080,
+    "name": "combiner",
+    "max_clients": 30
+}
+
+CLIENT_DEFAULTS = {
+    'discover_host': 'localhost',
+    'discover_port': 8092,
+}
+
+API_VERSION = 'v1'

--- a/fedn/cli/shared.py
+++ b/fedn/cli/shared.py
@@ -30,9 +30,9 @@ def get_api_url(protocol: str, host: str, port: str, endpoint: str) -> str:
     if _url:
         return f'{_url}/api/{API_VERSION}/{endpoint}'
 
-    _protocol = os.environ.get('FEDN_PROTOCOL') or protocol or CONTROLLER_DEFAULTS['protocol']
-    _host = os.environ.get('FEDN_HOST') or host or CONTROLLER_DEFAULTS['host']
-    _port = os.environ.get('FEDN_PORT') or port or CONTROLLER_DEFAULTS['port']
+    _protocol = protocol or os.environ.get('FEDN_PROTOCOL') or CONTROLLER_DEFAULTS['protocol']
+    _host = host or os.environ.get('FEDN_HOST') or CONTROLLER_DEFAULTS['host']
+    _port = port or os.environ.get('FEDN_PORT') or CONTROLLER_DEFAULTS['port']
 
     return f'{_protocol}://{_host}:{_port}/api/{API_VERSION}/{endpoint}'
 
@@ -46,3 +46,7 @@ def get_token(token: str) -> str:
     scheme = os.environ.get("FEDN_AUTH_SCHEME", "Bearer")
 
     return f"{scheme} {_token}"
+
+
+def get_client_package_path(path: str) -> str:
+    return path or os.environ.get('FEDN_PACKAGE_PATH', None)

--- a/fedn/cli/start_cmd.py
+++ b/fedn/cli/start_cmd.py
@@ -1,0 +1,47 @@
+import json
+
+import click
+import requests
+
+from .main import main
+from .shared import API_VERSION, CONTROLLER_DEFAULTS
+
+
+@main.group('start')
+@click.pass_context
+def start_cmd(ctx):
+    """
+    :param ctx:
+    """
+    pass
+
+
+@click.option('-h', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('-n', '--name', required=False, help='Name of session (session id).')
+@click.option('-v', '--validate', required=True, default=True, help='Validate the session. Set to False to skip validation.')
+@start_cmd.command('session')
+@click.pass_context
+def start_session(ctx, host: str, port: int, name: str = None, validate: bool = True):
+    """
+    - Start a session.
+    return: None
+    """
+    url = f'http://{host}:{port}/start_session'
+    headers = {'Content-Type': 'application/json'}
+
+    click.echo(f'\nStarting session: {url}\n')
+
+    try:
+
+        data = {'session_id': name, 'validate': validate}
+        response = requests.post(url, data=json.dumps(data), headers=headers)
+
+        if response.status_code == 200:
+            json_data = response.json()
+            click.echo(json.dumps(json_data, indent=4))
+        else:
+            click.echo("Something went wrong. Please try again.")
+
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')

--- a/fedn/cli/start_cmd.py
+++ b/fedn/cli/start_cmd.py
@@ -4,7 +4,7 @@ import click
 import requests
 
 from .main import main
-from .shared import API_VERSION, CONTROLLER_DEFAULTS
+from .shared import CONTROLLER_DEFAULTS
 
 
 @main.group('start')

--- a/fedn/cli/start_cmd.py
+++ b/fedn/cli/start_cmd.py
@@ -4,7 +4,7 @@ import click
 import requests
 
 from .main import main
-from .shared import CONTROLLER_DEFAULTS
+from .shared import CONTROLLER_DEFAULTS, get_token
 
 
 @main.group('start')
@@ -19,16 +19,22 @@ def start_cmd(ctx):
 @click.option('-h', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
 @click.option('-i', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
 @click.option('-n', '--name', required=False, help='Name of session (session id).')
+@click.option('-t', '--token', required=False, help='Authentication token')
 @click.option('-v', '--validate', required=True, default=True, help='Validate the session. Set to False to skip validation.')
 @start_cmd.command('session')
 @click.pass_context
-def start_session(ctx, host: str, port: int, name: str = None, validate: bool = True):
+def start_session(ctx, host: str, port: int, name: str = None, token: str = None, validate: bool = True):
     """
     - Start a session.
     return: None
     """
     url = f'http://{host}:{port}/start_session'
     headers = {'Content-Type': 'application/json'}
+
+    _token = get_token(token)
+
+    if _token is not None:
+        headers['Authorization'] = _token
 
     click.echo(f'\nStarting session: {url}\n')
 

--- a/fedn/cli/start_cmd.py
+++ b/fedn/cli/start_cmd.py
@@ -11,7 +11,7 @@ from .shared import API_VERSION, CONTROLLER_DEFAULTS
 @click.pass_context
 def start_cmd(ctx):
     """
-    :param ctx:
+    - Issue commands to the network.
     """
     pass
 

--- a/fedn/cli/upload_cmd.py
+++ b/fedn/cli/upload_cmd.py
@@ -49,13 +49,10 @@ def upload_package(ctx, host: str, port: int, helper: str, path: str, name: str 
 
 @click.option('-h', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
 @click.option('-i', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('-hl', '--helper', required=True, default="numpyhelper", help='Helper type to use.')
 @click.option('-p', '--path', required=True, help='Path to model file.')
-@click.option('-n', '--name', required=False, help='Name of model.')
-@click.option('-d', '--description', required=False, help='Description of model.')
 @upload_cmd.command('model')
 @click.pass_context
-def upload_model(ctx, host: str, port: int, helper: str, path: str, name: str = None, description: str = None):
+def upload_model(ctx, host: str, port: int, path: str):
     """
     - Upload a model to the controller.
     return: None
@@ -67,11 +64,10 @@ def upload_model(ctx, host: str, port: int, helper: str, path: str, name: str = 
 
     try:
         with open(path, 'rb') as file:
-            response = requests.post(url, files={'file': file}, data={
-                                     'helper': helper, 'name': name, 'description': description})
+            response = requests.post(url, files={'file': file})
 
             if response.status_code == 200:
-                click.echo("Success! model uploaded.")
+                click.echo("Success! Model uploaded.")
             else: 
                 click.echo("Something went wrong. Please try again.")
     except FileNotFoundError:

--- a/fedn/cli/upload_cmd.py
+++ b/fedn/cli/upload_cmd.py
@@ -14,7 +14,6 @@ def upload_cmd(ctx):
     pass
 
 
-
 @click.option('-h', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
 @click.option('-i', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
 @click.option('-hl', '--helper', required=True, default="numpyhelper", help='Helper type to use.')
@@ -40,6 +39,39 @@ def upload_package(ctx, host: str, port: int, helper: str, path: str, name: str 
 
             if response.status_code == 200:
                 click.echo("Success! Package uploaded.")
+            else: 
+                click.echo("Something went wrong. Please try again.")
+    except FileNotFoundError:
+        click.echo(f'Error: Could not find file {path}')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')
+
+
+@click.option('-h', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('-hl', '--helper', required=True, default="numpyhelper", help='Helper type to use.')
+@click.option('-p', '--path', required=True, help='Path to model file.')
+@click.option('-n', '--name', required=False, help='Name of model.')
+@click.option('-d', '--description', required=False, help='Description of model.')
+@upload_cmd.command('model')
+@click.pass_context
+def upload_model(ctx, host: str, port: int, helper: str, path: str, name: str = None, description: str = None):
+    """
+    - Upload a model to the controller.
+    return: None
+    """
+    url = f'http://{host}:{port}/set_initial_model'
+    headers = {}
+
+    click.echo(f'\nUploading model: {url}\n')
+
+    try:
+        with open(path, 'rb') as file:
+            response = requests.post(url, files={'file': file}, data={
+                                     'helper': helper, 'name': name, 'description': description})
+
+            if response.status_code == 200:
+                click.echo("Success! model uploaded.")
             else: 
                 click.echo("Something went wrong. Please try again.")
     except FileNotFoundError:

--- a/fedn/cli/upload_cmd.py
+++ b/fedn/cli/upload_cmd.py
@@ -17,6 +17,11 @@ def upload_cmd(ctx):
 
 
 def get_api_url(protocol: str, host: str, port: str, endpoint: str) -> str:
+    _url = os.environ.get('FEDN_CONTROLLER_URL')
+
+    if _url:
+        return f'{_url}/{endpoint}'
+
     _protocol = os.environ.get('FEDN_PROTOCOL') or protocol or CONTROLLER_DEFAULTS['protocol']
     _host = os.environ.get('FEDN_HOST') or host or CONTROLLER_DEFAULTS['host']
     _port = os.environ.get('FEDN_PORT') or port or CONTROLLER_DEFAULTS['port']

--- a/fedn/cli/upload_cmd.py
+++ b/fedn/cli/upload_cmd.py
@@ -1,0 +1,48 @@
+import click
+import requests
+
+from .main import main
+from .shared import API_VERSION, CONTROLLER_DEFAULTS
+
+
+@main.group('upload')
+@click.pass_context
+def upload_cmd(ctx):
+    """
+    :param ctx:
+    """
+    pass
+
+
+
+@click.option('-h', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-i', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('-hl', '--helper', required=True, default="numpyhelper", help='Helper type to use.')
+@click.option('-p', '--path', required=True, help='Path to package file.')
+@click.option('-n', '--name', required=False, help='Name of package.')
+@click.option('-d', '--description', required=False, help='Description of package.')
+@upload_cmd.command('package')
+@click.pass_context
+def upload_package(ctx, host: str, port: int, helper: str, path: str, name: str = None, description: str = None):
+    """
+    - Upload a package to the controller.
+    return: None
+    """
+    url = f'http://{host}:{port}/set_package'
+    headers = {}
+
+    click.echo(f'\nUploading package: {url}\n')
+
+    try:
+        with open(path, 'rb') as file:
+            response = requests.post(url, files={'file': file}, data={
+                                     'helper': helper, 'name': name, 'description': description})
+
+            if response.status_code == 200:
+                click.echo("Success! Package uploaded.")
+            else: 
+                click.echo("Something went wrong. Please try again.")
+    except FileNotFoundError:
+        click.echo(f'Error: Could not find file {path}')
+    except requests.exceptions.ConnectionError:
+        click.echo(f'Error: Could not connect to {host}:{port}')

--- a/fedn/cli/upload_cmd.py
+++ b/fedn/cli/upload_cmd.py
@@ -11,7 +11,7 @@ from .shared import CONTROLLER_DEFAULTS, get_token
 @click.pass_context
 def upload_cmd(ctx):
     """
-    :param ctx:
+    - Commands used to upload files to the controller.
     """
     pass
 

--- a/fedn/cli/upload_cmd.py
+++ b/fedn/cli/upload_cmd.py
@@ -1,8 +1,10 @@
+import os
+
 import click
 import requests
 
 from .main import main
-from .shared import API_VERSION, CONTROLLER_DEFAULTS
+from .shared import CONTROLLER_DEFAULTS, get_token
 
 
 @main.group('upload')
@@ -14,63 +16,88 @@ def upload_cmd(ctx):
     pass
 
 
-@click.option('-h', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('-hl', '--helper', required=True, default="numpyhelper", help='Helper type to use.')
-@click.option('-p', '--path', required=True, help='Path to package file.')
-@click.option('-n', '--name', required=False, help='Name of package.')
-@click.option('-d', '--description', required=False, help='Description of package.')
+def get_api_url(protocol: str, host: str, port: str, endpoint: str) -> str:
+    _protocol = os.environ.get('FEDN_PROTOCOL') or protocol or CONTROLLER_DEFAULTS['protocol']
+    _host = os.environ.get('FEDN_HOST') or host or CONTROLLER_DEFAULTS['host']
+    _port = os.environ.get('FEDN_PORT') or port or CONTROLLER_DEFAULTS['port']
+
+    return f'{_protocol}://{_host}:{_port}/{endpoint}'
+
+
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api)')
+@click.option('-P', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api)')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('-h', '--helper', required=True, default="numpyhelper", help='Helper type to use')
+@click.option('-path', '--path', required=True, help='Path to package file')
+@click.option('-n', '--name', required=False, help='Name of package')
+@click.option('-d', '--description', required=False, help='Description of package')
 @upload_cmd.command('package')
 @click.pass_context
-def upload_package(ctx, host: str, port: int, helper: str, path: str, name: str = None, description: str = None):
+def upload_package(ctx, protocol: str, host: str, port: int, token: str, helper: str, path: str, name: str = None, description: str = None):
     """
     - Upload a package to the controller.
     return: None
     """
-    url = f'http://{host}:{port}/set_package'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint="set_package")
     headers = {}
 
+    _token = get_token(token)
+
+    if _token is not None:
+        headers['Authorization'] = _token
+
     click.echo(f'\nUploading package: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         with open(path, 'rb') as file:
             response = requests.post(url, files={'file': file}, data={
-                                     'helper': helper, 'name': name, 'description': description})
+                                     'helper': helper, 'name': name, 'description': description}, headers=headers)
 
             if response.status_code == 200:
                 click.echo("Success! Package uploaded.")
-            else: 
+            else:
                 click.echo("Something went wrong. Please try again.")
     except FileNotFoundError:
         click.echo(f'Error: Could not find file {path}')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')
 
 
-@click.option('-h', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
-@click.option('-i', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
-@click.option('-p', '--path', required=True, help='Path to model file.')
+@click.option('-p', '--protocol', required=False, default=CONTROLLER_DEFAULTS['protocol'], help='Communication protocol of controller (api)')
+@click.option('-H', '--host', required=True, default=CONTROLLER_DEFAULTS['host'], help='Hostname of controller (api).')
+@click.option('-P', '--port', required=True, default=CONTROLLER_DEFAULTS['port'], help='Port of controller (api).')
+@click.option('-t', '--token', required=False, help='Authentication token')
+@click.option('-path', '--path', required=True, help='Path to model file.')
 @upload_cmd.command('model')
 @click.pass_context
-def upload_model(ctx, host: str, port: int, path: str):
+def upload_model(ctx, protocol: str, host: str, port: int, token: str, path: str):
     """
     - Upload a model to the controller.
     return: None
     """
-    url = f'http://{host}:{port}/set_initial_model'
+    url = get_api_url(protocol=protocol, host=host, port=port, endpoint="set_initial_model")
+
     headers = {}
 
+    _token = get_token(token)
+
+    if _token is not None:
+        headers['Authorization'] = _token
+
     click.echo(f'\nUploading model: {url}\n')
+    click.echo(f'Headers: {headers}')
 
     try:
         with open(path, 'rb') as file:
-            response = requests.post(url, files={'file': file})
+            response = requests.post(url, files={'file': file}, headers=headers)
 
             if response.status_code == 200:
                 click.echo("Success! Model uploaded.")
-            else: 
+            else:
                 click.echo("Something went wrong. Please try again.")
     except FileNotFoundError:
         click.echo(f'Error: Could not find file {path}')
     except requests.exceptions.ConnectionError:
-        click.echo(f'Error: Could not connect to {host}:{port}')
+        click.echo(f'Error: Could not connect to {url}')

--- a/fedn/fedn/common/config.py
+++ b/fedn/fedn/common/config.py
@@ -1,9 +1,40 @@
 import os
+from enum import Enum
 
 import yaml
 
 global STATESTORE_CONFIG
 global MODELSTORAGE_CONFIG
+
+
+class StorageType(Enum):
+    STATESTORE_CONFIG = 1,
+    MODELSTORAGE_CONFIG = 2
+
+
+fedn_config = {
+    "statestore": {
+        "type": "MongoDB",
+        "mongo_config": {
+            # "username": "admin",
+            # "password": "password",
+            "host": "localhost",
+            "port": 27017
+        }
+    },
+    "network_id": "fedn-network",
+    "controller": {
+        "host": "localhost",
+        "port": 8092,
+        "debug": True
+    },
+    "storage": {
+        "storage_type": "filesystem",
+        "storage_config": {
+            "storage_path": "/tmp/fedn/files"
+        }
+    }
+}
 
 
 def get_environment_config():
@@ -12,13 +43,37 @@ def get_environment_config():
     global STATESTORE_CONFIG
     global MODELSTORAGE_CONFIG
 
-    STATESTORE_CONFIG = os.environ.get('STATESTORE_CONFIG',
-                                       '/workspaces/fedn/config/settings-reducer.yaml.template')
-    MODELSTORAGE_CONFIG = os.environ.get('MODELSTORAGE_CONFIG',
-                                         '/workspaces/fedn/config/settings-reducer.yaml.template')
+    STATESTORE_CONFIG = os.environ.get('STATESTORE_CONFIG', None)
+    MODELSTORAGE_CONFIG = os.environ.get('MODELSTORAGE_CONFIG', None)
 
 
-def get_statestore_config(file=None):
+def get_config(file: str = None, storage_type: StorageType = StorageType.STATESTORE_CONFIG) -> dict:
+    """ Get the configuration from file.
+    If file is not provided, the environment variables are checked for the configuration file paths.
+    If the environment variables are not set, the default configuration is used (fedn_config).
+
+    :param file: The configuration file (yaml) path (optional).
+    :type file: str
+    :return: The configuration as a dict.
+    :rtype: dict
+    """
+    settings: dict = None
+
+    if file is None:
+        get_environment_config()
+        file = STATESTORE_CONFIG if storage_type == StorageType.STATESTORE_CONFIG else MODELSTORAGE_CONFIG
+
+    if file:
+        with open(file, 'r') as config_file:
+            try:
+                settings = dict(yaml.safe_load(config_file))
+            except yaml.YAMLError as e:
+                raise (e)
+
+    return settings or fedn_config
+
+
+def get_statestore_config(file: str = None):
     """ Get the statestore configuration from file.
 
     :param file: The statestore configuration file (yaml) path (optional).
@@ -26,14 +81,8 @@ def get_statestore_config(file=None):
     :return: The statestore configuration as a dict.
     :rtype: dict
     """
-    if file is None:
-        get_environment_config()
-        file = STATESTORE_CONFIG
-    with open(file, 'r') as config_file:
-        try:
-            settings = dict(yaml.safe_load(config_file))
-        except yaml.YAMLError as e:
-            raise (e)
+    settings: dict = get_config(file, StorageType.STATESTORE_CONFIG)
+
     return settings["statestore"]
 
 
@@ -45,14 +94,8 @@ def get_modelstorage_config(file=None):
     :return: The model storage configuration as a dict.
     :rtype: dict
     """
-    if file is None:
-        get_environment_config()
-        file = MODELSTORAGE_CONFIG
-    with open(file, 'r') as config_file:
-        try:
-            settings = dict(yaml.safe_load(config_file))
-        except yaml.YAMLError as e:
-            raise (e)
+    settings: dict = get_config(file, StorageType.MODELSTORAGE_CONFIG)
+
     return settings["storage"]
 
 
@@ -64,14 +107,8 @@ def get_network_config(file=None):
     :return: The network id.
     :rtype: str
     """
-    if file is None:
-        get_environment_config()
-        file = STATESTORE_CONFIG
-    with open(file, 'r') as config_file:
-        try:
-            settings = dict(yaml.safe_load(config_file))
-        except yaml.YAMLError as e:
-            raise (e)
+    settings: dict = get_config(file, StorageType.STATESTORE_CONFIG)
+
     return settings["network_id"]
 
 
@@ -83,12 +120,6 @@ def get_controller_config(file=None):
     :return: The controller configuration as a dict.
     :rtype: dict
     """
-    if file is None:
-        get_environment_config()
-        file = STATESTORE_CONFIG
-    with open(file, 'r') as config_file:
-        try:
-            settings = dict(yaml.safe_load(config_file))
-        except yaml.YAMLError as e:
-            raise (e)
+    settings: dict = get_config(file, StorageType.STATESTORE_CONFIG)
+
     return settings["controller"]

--- a/fedn/fedn/common/config.py
+++ b/fedn/fedn/common/config.py
@@ -16,8 +16,6 @@ fedn_config = {
     "statestore": {
         "type": "MongoDB",
         "mongo_config": {
-            # "username": "admin",
-            # "password": "password",
             "host": "localhost",
             "port": 27017
         }

--- a/fedn/fedn/network/api/interface.py
+++ b/fedn/fedn/network/api/interface.py
@@ -390,18 +390,18 @@ class API:
             mutex.acquire()
             # TODO: make configurable, perhaps in config.py or package.py
             return send_from_directory(
-                "/app/client/package/", name, as_attachment=True
+                self.local_path, name, as_attachment=True
             )
         except Exception:
             try:
                 data = self.control.get_compute_package(name)
                 # TODO: make configurable, perhaps in config.py or package.py
-                file_path = os.path.join("/app/client/package/", name)
+                file_path = os.path.join(self.local_path, name)
                 with open(file_path, "wb") as fh:
                     fh.write(data)
                 # TODO: make configurable, perhaps in config.py or package.py
                 return send_from_directory(
-                    "/app/client/package/", name, as_attachment=True
+                    self.local_path, name, as_attachment=True
                 )
             except Exception:
                 raise

--- a/fedn/fedn/network/api/interface.py
+++ b/fedn/fedn/network/api/interface.py
@@ -25,6 +25,10 @@ class API:
         self.statestore = statestore
         self.control = control
         self.name = "api"
+        # TODO: make configurable, perhaps in config.py or package.py
+        self.local_path = os.path.expanduser("~/.fedn/tmp_dir")
+        if not os.path.exists(self.local_path):
+            os.makedirs(self.local_path)
 
     def _to_dict(self):
         """Convert the object to a dict.
@@ -240,7 +244,7 @@ class API:
         file_name = file.filename
         storage_file_name = secure_filename(f"{str(uuid.uuid4())}.{extension}")
 
-        file_path = os.path.join("/app/client/package/", storage_file_name)
+        file_path = os.path.join(self.local_path, file_name)
         file.save(file_path)
 
         self.control.set_compute_package(storage_file_name, file_path)

--- a/fedn/fedn/network/api/server.py
+++ b/fedn/fedn/network/api/server.py
@@ -1,4 +1,3 @@
-from flasgger import Swagger
 from flask import Flask, jsonify, request
 
 from fedn.common.config import (get_controller_config, get_modelstorage_config,
@@ -31,17 +30,6 @@ app.register_blueprint(package_bp)
 app.register_blueprint(session_bp)
 app.register_blueprint(combiner_bp)
 app.register_blueprint(round_bp)
-
-template = {
-  "swagger": "2.0",
-  "info": {
-    "title": "FEDn API",
-    "description": "API for the FEDn network.",
-    "version": "0.0.1"
-  }
-}
-
-swagger = Swagger(app, template=template)
 
 
 @app.route("/get_model_trail", methods=["GET"])
@@ -502,8 +490,14 @@ def get_plot_data():
     return response
 
 
-if __name__ == "__main__":
-    config = get_controller_config()
+def start_api(config: dict = None):
+    if config is None:
+        config = get_controller_config()
+
     port = config["port"]
     debug = config["debug"]
     app.run(debug=debug, port=port, host="0.0.0.0")
+
+
+if __name__ == "__main__":
+    start_api()

--- a/fedn/fedn/network/clients/client.py
+++ b/fedn/fedn/network/clients/client.py
@@ -346,15 +346,17 @@ class Client:
             except Exception as e:
                 logger.error(f"Caught exception: {type(e).__name__}")
         else:
-            run_path: str
+            from_path: str = None
+            run_path: str = None
 
-            if "package_path" in config and config["package_path"]:
-                run_path = f"{config['package_path']}/client"
+            if "package_dir" in config and config["package_dir"]:
+                path = f"{config['package_dir']}"
+                run_path = f"{config['package_dir']}"
+                from_path = path
             else:
                 run_path = os.path.join(os.getcwd(), 'client')
 
-
-            self.dispatcher = pr.dispatcher(run_path)
+            self.dispatcher = pr.dispatcher(run_path, from_path=from_path)
 
     def get_model_from_combiner(self, id, timeout=20):
         """Fetch a model from the assigned combiner.

--- a/fedn/fedn/network/clients/connect.py
+++ b/fedn/fedn/network/clients/connect.py
@@ -105,13 +105,6 @@ class ConnectorClient:
 
                 return Status.TryAgain, reason
 
-            reducer_package = retval.json()['package']
-            if reducer_package != self.package:
-                reason = "Unmatched config of compute package between client and reducer.\n" +\
-                    "Reducer uses {} package and client uses {}.".format(
-                        reducer_package, self.package)
-                return Status.UnMatchedConfig, reason
-
             return Status.Assigned, retval.json()
 
         return Status.Unassigned, None

--- a/fedn/fedn/network/clients/package.py
+++ b/fedn/fedn/network/clients/package.py
@@ -144,18 +144,20 @@ class PackageRuntime:
             logger.error("Error extracting files.")
             return False
 
-    def dispatcher(self, run_path):
+    def dispatcher(self, run_path: str, from_path: str = None):
         """ Dispatch the compute package
 
         :param run_path: path to dispatch the compute package
         :type run_path: str
+        :param from_path: path to the compute package
+        :type from_path: str
         :return: Dispatcher object
         :rtype: :class:`fedn.utils.dispatcher.Dispatcher`
         """
-        from_path = os.path.join(os.getcwd(), 'client')
+        _from_path = from_path or os.path.join(os.getcwd(), 'client')
 
         # preserve_times=False ensures compatibility with Gramine LibOS
-        copy_tree(from_path, run_path, preserve_times=False)
+        copy_tree(_from_path, run_path, preserve_times=False)
 
         try:
             cfg = None

--- a/fedn/fedn/network/combiner/combiner.py
+++ b/fedn/fedn/network/combiner/combiner.py
@@ -18,6 +18,8 @@ from fedn.network.combiner.connect import ConnectorCombiner, Status
 from fedn.network.combiner.modelservice import ModelService
 from fedn.network.combiner.roundhandler import RoundHandler
 from fedn.network.grpc.server import Server
+from fedn.network.storage.filesystem.repository import \
+    LocalFileSystemModelRepository
 from fedn.network.storage.s3.repository import Repository
 from fedn.network.storage.statestore.mongostatestore import MongoStateStore
 
@@ -123,8 +125,12 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         print(announce_config, flush=True)
 
         # Set up model repository
-        self.repository = Repository(
-            announce_config['storage']['storage_config'])
+        if announce_config['storage']['storage_type'] == 'filesystem':
+            storage_path = announce_config['storage']['storage_config'].get('storage_path', './')
+            self.repository = LocalFileSystemModelRepository(storage_path)
+        else:
+            self.repository = Repository(
+                announce_config['storage']['storage_config'])
 
         self.statestore = MongoStateStore(
             announce_config['statestore']['network_id'],

--- a/fedn/fedn/network/controller/controlbase.py
+++ b/fedn/fedn/network/controller/controlbase.py
@@ -8,6 +8,8 @@ from fedn.common.log_config import logger
 from fedn.network.api.network import Network
 from fedn.network.combiner.interfaces import CombinerUnavailableError
 from fedn.network.state import ReducerState
+from fedn.network.storage.filesystem.repository import \
+    LocalFileSystemModelRepository
 from fedn.network.storage.s3.repository import Repository
 
 # Maximum number of tries to connect to statestore and retrieve storage configuration
@@ -64,6 +66,9 @@ class ControlBase(ABC):
             self.model_repository = Repository(
                 storage_config["storage_config"]
             )
+        elif storage_config['storage_type'] == "filesystem":
+            storage_path = storage_config['storage_config'].get('storage_path', './')
+            self.model_repository = LocalFileSystemModelRepository(storage_path)
         else:
             logger.error("Unsupported storage backend, exiting.")
             raise UnsupportedStorageBackend()

--- a/fedn/fedn/network/storage/filesystem/repository.py
+++ b/fedn/fedn/network/storage/filesystem/repository.py
@@ -68,3 +68,10 @@ class LocalFileSystemModelRepository:
             os.remove(package_path)
         else:
             raise FileNotFoundError(f"Compute package {compute_package} not found.")
+        
+    def delete_model(self, model_id):
+        model_path = self.get_model_path(model_id)
+        if os.path.exists(model_path):
+            os.remove(model_path)
+        else:
+            raise FileNotFoundError(f"Model with ID {model_id} not found.")

--- a/fedn/fedn/network/storage/filesystem/repository.py
+++ b/fedn/fedn/network/storage/filesystem/repository.py
@@ -1,5 +1,6 @@
 import os
 import uuid
+from io import BytesIO
 
 
 class LocalFileSystemModelRepository:
@@ -22,7 +23,9 @@ class LocalFileSystemModelRepository:
     def get_model_stream(self, model_id):
         model_path = self.get_model_path(model_id)
         if os.path.exists(model_path):
-            return open(model_path, 'rb')
+            with open(model_path, 'rb') as file:
+                byte_io = BytesIO(file.read())
+                return byte_io
         else:
             raise FileNotFoundError(f"Model with ID {model_id} not found.")
 

--- a/fedn/fedn/network/storage/filesystem/repository.py
+++ b/fedn/fedn/network/storage/filesystem/repository.py
@@ -1,0 +1,67 @@
+import os
+import uuid
+
+
+class LocalFileSystemModelRepository:
+    def __init__(self, directory='./'):
+        self.directory = directory
+        if not os.path.exists(directory):
+            os.makedirs(directory)
+
+    def get_model_path(self, model_id):
+        return os.path.join(self.directory, model_id)
+
+    def get_model(self, model_id):
+        model_path = self.get_model_path(model_id)
+        if os.path.exists(model_path):
+            with open(model_path, 'rb') as file:
+                return file.read()
+        else:
+            raise FileNotFoundError(f"Model with ID {model_id} not found.")
+
+    def get_model_stream(self, model_id):
+        model_path = self.get_model_path(model_id)
+        if os.path.exists(model_path):
+            return open(model_path, 'rb')
+        else:
+            raise FileNotFoundError(f"Model with ID {model_id} not found.")
+
+    def set_model(self, model, is_file=True):
+        model_id = str(uuid.uuid4())
+        model_path = self.get_model_path(model_id)
+
+        if is_file:
+            # If model is a file path, copy the file content.
+            with open(model, 'rb') as src, open(model_path, 'wb') as dst:
+                dst.write(src.read())
+        else:
+            # If model is a binary content, write it directly.
+            with open(model_path, 'wb') as file:
+                file.write(model)
+
+        return model_id
+
+    # Methods for compute_package can be similarly implemented
+    def set_compute_package(self, name, compute_package, is_file=True):
+        package_path = self.get_model_path(name)
+        if is_file:
+            with open(compute_package, 'rb') as src, open(package_path, 'wb') as dst:
+                dst.write(src.read())
+        else:
+            with open(package_path, 'wb') as file:
+                file.write(compute_package)
+
+    def get_compute_package(self, compute_package):
+        package_path = self.get_model_path(compute_package)
+        if os.path.exists(package_path):
+            with open(package_path, 'rb') as file:
+                return file.read()
+        else:
+            raise FileNotFoundError(f"Compute package {compute_package} not found.")
+
+    def delete_compute_package(self, compute_package):
+        package_path = self.get_model_path(compute_package)
+        if os.path.exists(package_path):
+            os.remove(package_path)
+        else:
+            raise FileNotFoundError(f"Compute package {compute_package} not found.")

--- a/fedn/setup.py
+++ b/fedn/setup.py
@@ -18,7 +18,7 @@ setup(
         "grpcio~=1.57.0",
         "grpcio-tools~=1.57.0",
         "numpy>=1.21.6",
-        "protobuf",
+        "protobuf>=4.21.0,<5.0.0",
         "pymongo",
         "Flask",
         "Flask-WTF",

--- a/fedn/setup.py
+++ b/fedn/setup.py
@@ -32,8 +32,7 @@ setup(
         "pandas",
         "bokeh<3.0.0",
         "networkx",
-        "grpcio-health-checking~=1.57.0",
-        "flasgger==0.9.5"
+        "grpcio-health-checking~=1.57.0"
     ],
     license='Apache 2.0',
     zip_safe=False,

--- a/fedn/setup.py
+++ b/fedn/setup.py
@@ -26,7 +26,7 @@ setup(
         "pyopenssl",
         "ttictoc",
         "psutil",
-        "click==8.0.1",
+        "click==8.1.7",
         "jinja2",
         "plotly",
         "pandas",


### PR DESCRIPTION
# FEDn cli

_Run FEDn, list entities, start sessions etc. Default to running commands for localhost but can be configured, either by params or ENV:s._

**Config includes:**
- FEDN_PROTOCOL - communication protocol (default http)
- FEDN_HOST - controller host (default localhost)
- FEDN_PORT - controller port (default 8092)
- FEDN_TOKEN - token (used for authentication in FEDn Studio)
- FEDN_AUTH_SCHEME - token auth scheme (Bearer/Token) 

## Added commands:

**fedn run**
- start controller and combiner

**fedn list <entity>**
- list entities (models, packages, clients etc)

**fedn start session**
- start a new session

**fedn upload <type>**
- upload compute package or seed model

**fedn config**
- see currently set ENV:s used as config
- _fedn config generate_ can be used to generate script to set the ENV:s
- _fedn config clear_ can be used to generate script to clear the ENV:s 

