### PR TITLE
Feature/SK-726 | Refactor APIClient

### DIFF
--- a/.ci/tests/examples/api_test.py
+++ b/.ci/tests/examples/api_test.py
@@ -134,7 +134,7 @@ if __name__ == '__main__':
     client = APIClient(host="localhost", port=8092)
     fire.Fire({
         'set_seed': client.set_active_model,
-        'set_package': client.set_package_active,
+        'set_package': client.set_active_package,
         'start_session': client.start_session,
         'get_client_config': _download_config,
         'test_api_get_methods': test_api_get_methods,

--- a/.ci/tests/examples/api_test.py
+++ b/.ci/tests/examples/api_test.py
@@ -18,65 +18,123 @@ def _download_config(output):
 
 def test_api_get_methods():
     client = APIClient(host="localhost", port=8092)
-    status = client.get_controller_status()
-    assert status
-    print("Controller status: ", status, flush=True)
 
-    events = client.get_events()
-    assert events
-    print("Events: ", events, flush=True)
-
-    validations = client.list_validations()
-    assert validations
-    print("Validations: ", validations, flush=True)
-
-    models = client.get_model_trail()
-    assert models
-    print("Models: ", models, flush=True)
-
-    clients = client.list_clients()
+    # --- Clients --- #
+    clients = client.get_clients()
     assert clients
     print("Clients: ", clients, flush=True)
 
-    combiners = client.list_combiners()
+    active_clients = client.get_active_clients()
+    assert active_clients
+    print("Active clients: ", active_clients, flush=True)
+
+    clients_count = client.get_clients_count()
+    assert clients_count
+    print("Clients count: ", clients_count, flush=True)
+
+    # --- Combiners --- #
+
+    combiners = client.get_combiners()
     assert combiners
     print("Combiners: ", combiners, flush=True)
+
+    combiners_count = client.get_combiners_count()
+    assert combiners_count
+    print("Combiners count: ", combiners_count, flush=True)
 
     combiner = client.get_combiner("combiner")
     assert combiner
     print("Combiner: ", combiner, flush=True)
 
-    first_model = client.get_initial_model()
-    assert first_model
-    print("First model: ", first_model, flush=True)
+    # --- Controllers --- #
 
-    package = client.get_package()
-    assert package
-    print("Package: ", package, flush=True)
+    status = client.get_controller_status()
+    assert status
+    print("Controller status: ", status, flush=True)
+
+    # --- Models --- #
+
+    models = client.get_models()
+    assert models
+    print("Models: ", models, flush=True)
+
+    models_count = client.get_models_count()
+    assert models_count
+    print("Models count: ", models_count, flush=True)
+
+    models_from_trail = client.get_model_trail()
+    assert models_from_trail
+    print("Models: ", models_from_trail, flush=True)
+
+    active_model = client.get_active_model()
+    assert active_model
+    print("Active model: ", active_model, flush=True)
+
+    # --- Packages --- #
+
+    packages = client.get_packages()
+    assert packages
+    print("Packages: ", packages, flush=True)
+
+    packages_count = client.get_packages_count()
+    assert packages_count
+    print("Packages count: ", packages_count, flush=True)
+
+    active_package = client.get_active_package()
+    assert active_package
+    print("Active package: ", active_package, flush=True)
 
     checksum = client.get_package_checksum()
     assert checksum
     print("Checksum: ", checksum, flush=True)
 
-    rounds = client.list_rounds()
+    # --- Rounds --- #
+
+    rounds = client.get_rounds()
     assert rounds
     print("Rounds: ", rounds, flush=True)
 
-    round = client.get_round(1)
-    assert round
-    print("Round: ", round, flush=True)
+    rounds_count = client.get_rounds_count()
+    assert rounds_count
+    print("Rounds count: ", rounds_count, flush=True)
 
-    sessions = client.list_sessions()
+    # --- Sessions --- #
+
+    sessions = client.get_sessions()
     assert sessions
     print("Sessions: ", sessions, flush=True)
+
+    sessions_count = client.get_sessions_count()
+    assert sessions_count
+    print("Sessions count: ", sessions_count, flush=True)
+
+    # --- Statuses --- #
+
+    statuses = client.get_statuses()
+    assert statuses
+    print("Statuses: ", statuses, flush=True)
+
+    statuses_count = client.get_statuses_count()
+    assert statuses_count
+    print("Statuses count: ", statuses_count, flush=True)
+
+    # --- Validations --- #
+
+    validations = client.get_validations()
+    assert validations
+    print("Validations: ", validations, flush=True)
+
+    validations_count = client.get_validations_count()
+    assert validations_count
+    print("Validations count: ", validations_count, flush=True)
 
 
 if __name__ == '__main__':
 
     client = APIClient(host="localhost", port=8092)
     fire.Fire({
-        'set_seed': client.set_initial_model,
-        'set_package': client.set_package,
+        'set_seed': client.set_active_model,
+        'set_package': client.set_package_active,
         'start_session': client.start_session,
         'get_client_config': _download_config,
         'test_api_get_methods': test_api_get_methods,

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -82,8 +82,8 @@ Upload the compute package and seed model to FEDn:
 
    >>> from fedn import APIClient
    >>> client = APIClient(host="localhost", port=8092)
-   >>> client.set_package("package.tgz", helper="numpyhelper")
-   >>> client.set_initial_model("seed.npz")
+   >>> client.set_active_package("package.tgz", helper="numpyhelper")
+   >>> client.set_active_model("seed.npz")
 
 Configure and attach clients
 -------------
@@ -151,7 +151,7 @@ You are now ready to start training the model. In the python enviroment you inst
    # Show model trail:
    >>> client.get_model_trail()
    # Show model performance:
-   >>> client.list_validations()
+   >>> client.get_validations()
 
 Please see :py:mod:`fedn.network.api` for more details on the APIClient. 
 

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -271,20 +271,6 @@ class APIClient:
 
         return _json
 
-    def get_model_parameters(self, id: str):
-        """ Get the parameters of a model.
-
-        :param id: The id (or model property) of the model to get parameters for.
-        :type id: str
-        :return: The parameters of the model.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url_api_v1(f'models/{id}/parameters'), verify=self.verify, headers=self.headers)
-
-        _json = response.json()
-
-        return _json
-
     def get_model_trail(self, id: str = None, include_self: bool = True, reverse: bool = True, n_max: int = None):
         """ Get the model trail.
 

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -340,19 +340,7 @@ class APIClient:
         status = self.get_session_status(id)
         return status and status.lower() == "finished"
 
-    def get_client_config(self, checksum=True):
-        """ Get the controller configuration. Optionally include the checksum.
-        The config is used for clients to connect to the controller and ask for combiner assignment.
-
-        :param checksum: Whether to include the checksum of the package.
-        :type checksum: bool
-        :return: The client configuration.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url('get_client_config'), params={'checksum': checksum}, verify=self.verify, headers=self.headers)
-        return response.json()
-
-
+    # --- Packages --- #
 
     def set_package(self, path: str, helper: str, name: str = None, description: str = None):
         """ Set the compute package in the statestore.
@@ -375,19 +363,30 @@ class APIClient:
         :return: The compute package with info.
         :rtype: dict
         """
-        response = requests.get(self._get_url('get_package'), verify=self.verify, headers=self.headers)
-        return response.json()
+        response = requests.get(self._get_url_api_v1('packages/active'), verify=self.verify, headers=self.headers)
 
-    def list_compute_packages(self):
+        _json = response.json()
+
+        return _json
+
+    def list_compute_packages(self, n_max: int = None):
         """ Get all compute packages from the statestore.
 
         :return: All compute packages with info.
         :rtype: dict
         """
-        response = requests.get(self._get_url('list_compute_packages'), verify=self.verify, headers=self.headers)
-        return response.json()
+        _headers = self.headers.copy()
 
-    def download_package(self, path):
+        if n_max:
+            _headers['X-Limit'] = str(n_max)
+
+        response = requests.get(self._get_url_api_v1('packages'), verify=self.verify, headers=_headers)
+        
+        _json = response.json()
+
+        return _json
+
+    def download_package(self, path: str):
         """ Download the compute package.
 
         :param path: The path to download the compute package to.
@@ -411,6 +410,20 @@ class APIClient:
         """
         response = requests.get(self._get_url('get_package_checksum'), verify=self.verify, headers=self.headers)
         return response.json()
+
+    def get_client_config(self, checksum=True):
+        """ Get the controller configuration. Optionally include the checksum.
+        The config is used for clients to connect to the controller and ask for combiner assignment.
+
+        :param checksum: Whether to include the checksum of the package.
+        :type checksum: bool
+        :return: The client configuration.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url('get_client_config'), params={'checksum': checksum}, verify=self.verify, headers=self.headers)
+        return response.json()
+
+    # --- Controller --- #
 
     def get_controller_status(self):
         """ Get the status of the controller.

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -155,13 +155,46 @@ class APIClient:
 
         if combiner_id:
             _params['combiner'] = combiner_id
-        
+
         _headers = self.headers.copy()
 
         if n_max:
             _headers['X-Limit'] = str(n_max)
 
         response = requests.get(self._get_url_api_v1('clients'), params=_params, verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+    
+    # --- Combiners --- #
+
+    def list_combiners(self, n_max: int = None):
+        """ Get all combiners in the network.
+
+        :return: All combiners with info.
+        :rtype: dict
+        """
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers['X-Limit'] = str(n_max)
+        
+        response = requests.get(self._get_url_api_v1('combiners'), verify=self.verify, headers=_headers)
+        
+        _json = response.json()
+
+        return _json
+
+    def get_combiner(self, id: str):
+        """ Get a combiner from the statestore.
+
+        :param id: The combiner id to get.
+        :type id: str
+        :return: The combiner info.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'combiners/{id}'), verify=self.verify, headers=self.headers)
 
         _json = response.json()
 
@@ -179,25 +212,6 @@ class APIClient:
         response = requests.get(self._get_url('get_client_config'), params={'checksum': checksum}, verify=self.verify, headers=self.headers)
         return response.json()
 
-    def list_combiners(self):
-        """ Get all combiners in the network.
-
-        :return: All combiners with info.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url('list_combiners'), verify=self.verify, headers=self.headers)
-        return response.json()
-
-    def get_combiner(self, combiner_id):
-        """ Get a combiner from the statestore.
-
-        :param combiner_id: The combiner id to get.
-        :type combiner_id: str
-        :return: The combiner info.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url(f'get_combiner?combiner={combiner_id}'), verify=self.verify, headers=self.headers)
-        return response.json()
 
     def list_rounds(self):
         """ Get all rounds from the statestore.

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -434,7 +434,7 @@ class APIClient:
         else:
             return {'success': False, 'message': 'Failed to download package.'}
 
-    def set_package(self, path: str, helper: str, name: str = None, description: str = None):
+    def set_package_active(self, path: str, helper: str, name: str = None, description: str = None):
         """ Set the compute package in the statestore.
 
         :param path: The file path of the compute package to set.

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -165,7 +165,7 @@ class APIClient:
         :rtype: dict
         """
         response = requests.get(self._get_url('get_controller_status'), verify=self.verify, headers=self.headers)
-        
+
         _json = response.json()
 
         return _json
@@ -225,6 +225,20 @@ class APIClient:
 
         return _json
 
+    def get_model_parameters(self, id: str):
+        """ Get the parameters of a model.
+
+        :param id: The model id to get parameters for.
+        :type id: str
+        :return: The parameters of the model.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'models/{id}/parameters'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
     def get_model_trail(self, id: str = None, n_max: int = None):
         """ Get the model trail.
 
@@ -247,6 +261,26 @@ class APIClient:
         _json = response.json()
 
         return _json
+
+    def download_model(self, id: str, path: str):
+        """ Download the model with id id.
+
+        :param id: The model id to download.
+        :type id: str
+        :param path: The path to download the model to.
+        :type path: str
+        :return: Message with success or failure.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'models/{id}/download'), verify=self.verify, headers=self.headers)
+
+        if response.status_code == 200:
+
+            with open(path, 'wb') as file:
+                file.write(response.content)
+            return {'success': True, 'message': 'Model downloaded successfully.'}
+        else:
+            return {'success': False, 'message': 'Failed to download model.'}
 
     def set_model(self, path):
         """ Set the initial model in the statestore and upload to model repository.

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -179,9 +179,9 @@ class APIClient:
 
         if n_max:
             _headers['X-Limit'] = str(n_max)
-        
+
         response = requests.get(self._get_url_api_v1('combiners'), verify=self.verify, headers=_headers)
-        
+
         _json = response.json()
 
         return _json
@@ -200,6 +200,39 @@ class APIClient:
 
         return _json
 
+    # --- Rounds --- #
+
+    def list_rounds(self, n_max: int = None):
+        """ Get all rounds from the statestore.
+
+        :return: All rounds with config and metrics.
+        :rtype: dict
+        """
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers['X-Limit'] = str(n_max)
+
+        response = requests.get(self._get_url_api_v1('rounds'), verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_round(self, id: str):
+        """ Get a round from the statestore.
+
+        :param round_id: The round id to get.
+        :type round_id: str
+        :return: The round config and metrics.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'rounds/{id}'), verify=self.verify, headers=self.headers)
+        
+        _json = response.json()
+
+        return _json
+
     def get_client_config(self, checksum=True):
         """ Get the controller configuration. Optionally include the checksum.
         The config is used for clients to connect to the controller and ask for combiner assignment.
@@ -212,26 +245,6 @@ class APIClient:
         response = requests.get(self._get_url('get_client_config'), params={'checksum': checksum}, verify=self.verify, headers=self.headers)
         return response.json()
 
-
-    def list_rounds(self):
-        """ Get all rounds from the statestore.
-
-        :return: All rounds with config and metrics.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url('list_rounds'), verify=self.verify, headers=self.headers)
-        return response.json()
-
-    def get_round(self, round_id):
-        """ Get a round from the statestore.
-
-        :param round_id: The round id to get.
-        :type round_id: str
-        :return: The round config and metrics.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url(f'get_round?round_id={round_id}'), verify=self.verify, headers=self.headers)
-        return response.json()
 
     def start_session(self, session_id=None, aggregator='fedavg', model_id=None, round_timeout=180, rounds=5, round_buffer_size=-1, delete_models=True,
                       validate=True, helper='numpyhelper', min_clients=1, requested_clients=8):

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -434,7 +434,7 @@ class APIClient:
         else:
             return {'success': False, 'message': 'Failed to download package.'}
 
-    def set_package_active(self, path: str, helper: str, name: str = None, description: str = None):
+    def set_active_package(self, path: str, helper: str, name: str = None, description: str = None):
         """ Set the compute package in the statestore.
 
         :param path: The file path of the compute package to set.

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -537,7 +537,7 @@ class APIClient:
         :rtype: dict
         """
         response = requests.post(self._get_url('start_session'), json={
-            'id': id,
+            'session_id': id,
             'aggregator': aggregator,
             'model_id': model_id,
             'round_timeout': round_timeout,

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -677,7 +677,7 @@ class APIClient:
         _headers = self.headers.copy()
 
         if n_max:
-            _headers['X-Limit'] = str(n_max)        
+            _headers['X-Limit'] = str(n_max)
 
         response = requests.get(self._get_url_api_v1('statuses'), params=_params, verify=self.verify, headers=_headers)
 

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -218,6 +218,18 @@ class APIClient:
 
         return _json
 
+    def get_models_count(self):
+        """ Get the number of models in the statestore.
+
+        :return: The number of models.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('models/count'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
     def get_active_model(self):
         """ Get the latest model from the statestore.
 
@@ -260,7 +272,7 @@ class APIClient:
         :rtype: dict
         """
         if not id:
-            model = self.get_latest_model()
+            model = self.get_active_model()
             if "id" in model:
                 id = model["id"]
             else:
@@ -268,10 +280,10 @@ class APIClient:
 
         _headers = self.headers.copy()
 
-        if n_max:
-            _headers['X-Limit'] = str(n_max)
+        _count: int = n_max if n_max else self.get_models_count()
+        _headers['X-Limit'] = str(_count)
 
-        response = requests.get(self._get_url_api_v1(f'models/{id}/ancestors'), verify=self.verify, headers=self.headers)
+        response = requests.get(self._get_url_api_v1(f'models/{id}/ancestors'), verify=self.verify, headers=_headers)
         _json = response.json()
 
         return _json
@@ -487,7 +499,7 @@ class APIClient:
 
         return "Could not retrieve session status."
 
-    def get_session_is_finished(self, id: str):
+    def session_is_finished(self, id: str):
         """ Check if a session with id has finished.
 
         :param id: The id of the session to get.

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -261,7 +261,7 @@ class APIClient:
 
         return _json
 
-    def get_model_trail(self, id: str = None, n_max: int = None):
+    def get_model_trail(self, id: str = None, include_self: bool = True, reverse: bool = True, n_max: int = None):
         """ Get the model trail.
 
         :param id: The id (or model property) of the model to start the trail from. (optional)
@@ -282,8 +282,11 @@ class APIClient:
 
         _count: int = n_max if n_max else self.get_models_count()
         _headers['X-Limit'] = str(_count)
+        _headers['X-Reverse'] = "true" if reverse else "false"
 
-        response = requests.get(self._get_url_api_v1(f'models/{id}/ancestors'), verify=self.verify, headers=_headers)
+        _include_self_str: str = "true" if include_self else "false"
+
+        response = requests.get(self._get_url_api_v1(f'models/{id}/ancestors?include_self={_include_self_str}'), verify=self.verify, headers=_headers)
         _json = response.json()
 
         return _json

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -148,7 +148,11 @@ class APIClient:
         :return: The client configuration.
         :rtype: dict
         """
-        response = requests.get(self._get_url('get_client_config'), params={'checksum': checksum}, verify=self.verify, headers=self.headers)
+        _params = {
+            'checksum': "true" if checksum else "false"
+        }
+
+        response = requests.get(self._get_url('get_client_config'), params=_params, verify=self.verify, headers=self.headers)
 
         _json = response.json()
 
@@ -440,8 +444,17 @@ class APIClient:
         status = self.get_session_status(id)
         return status and status.lower() == "finished"
 
-    def start_session(self, id: str = None, aggregator: str = 'fedavg', model_id:  str = None, round_timeout: int = 180, rounds: int = 5, round_buffer_size: int = -1, delete_models: bool = True,
-                      validate: bool = True, helper: str = 'numpyhelper', min_clients: int = 1, requested_clients: int = 8):
+    def start_session(
+            self,
+            id: str = None,
+            aggregator: str = 'fedavg',
+            model_id:  str = None,
+            round_timeout: int = 180,
+            rounds: int = 5,
+            round_buffer_size: int = -1,
+            delete_models: bool = True,
+            validate: bool = True, helper: str = 'numpyhelper', min_clients: int = 1, requested_clients: int = 8
+    ):
         """ Start a new session.
 
         :param id: The session id to start.

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -1,4 +1,3 @@
-import json
 import os
 
 import requests
@@ -48,85 +47,23 @@ class APIClient:
     def _get_url_api_v1(self, endpoint):
         return self._get_url(f'api/v1/{endpoint}')
 
-    # --- Models --- #
-
-    def get_latest_model(self):
-        """ Get the latest model from the statestore.
-
-        :return: The latest model id.
-        :rtype: dict
-        """
-        _headers = self.headers.copy()
-        _headers['X-Limit'] = "1"
-
-        response = requests.get(self._get_url_api_v1('models'), verify=self.verify, headers=_headers)
-        _json = response.json()
-
-        if "result" in _json and len(_json["result"]) > 0:
-            return _json["result"][0]
-
-        return _json
-
-    def set_initial_model(self, path):
-        """ Set the initial model in the statestore and upload to model repository.
-
-        :param path: The file path of the initial model to set.
-        :type path: str
-        :return: A dict with success or failure message.
-        :rtype: dict
-        """
-        with open(path, 'rb') as file:
-            response = requests.post(self._get_url('set_initial_model'), files={'file': file}, verify=self.verify, headers=self.headers)
-        return response.json()
-
-    def get_model_trail(self, id: str = None, n_max: int = None):
-        """ Get the model trail.
-
-        :return: The model trail as dict including commit timestamp.
-        :rtype: dict
-        """
-        if not id:
-            model = self.get_latest_model()
-            if "id" in model:
-                id = model["id"]
-            else:
-                return model
-
-        _headers = self.headers.copy()
-
-        if n_max:
-            _headers['X-Limit'] = str(n_max)
-
-        response = requests.get(self._get_url_api_v1(f'models/{id}/ancestors'), verify=self.verify, headers=self.headers)
-        _json = response.json()
-
-        return _json
-
-    def list_models(self, session_id: str = None, n_max: int = None):
-        """ Get all models from the statestore.
-
-        :return: All models.
-        :rtype: dict
-        """
-        _params = {}
-
-        if session_id:
-            _params['session_id'] = session_id
-
-        _headers = self.headers.copy()
-
-        if n_max:
-            _headers['X-Limit'] = str(n_max)
-
-        response = requests.get(self._get_url_api_v1('models'), params=_params, verify=self.verify, headers=_headers)
-
-        _json = response.json()
-
-        return _json
-
     # --- Clients --- #
 
-    def list_clients(self, n_max: int = None):
+    def get_client(self, id: str):
+        """ Get a client from the statestore.
+
+        :param id: The client id to get.
+        :type id: str
+        :return: The client info.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'clients/{id}'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_clients(self, n_max: int = None):
         """ Get all clients from the statestore.
 
         return: All clients.
@@ -166,10 +103,24 @@ class APIClient:
         _json = response.json()
 
         return _json
-    
+
     # --- Combiners --- #
 
-    def list_combiners(self, n_max: int = None):
+    def get_combiner(self, id: str):
+        """ Get a combiner from the statestore.
+
+        :param id: The combiner id to get.
+        :type id: str
+        :return: The combiner info.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'combiners/{id}'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_combiners(self, n_max: int = None):
         """ Get all combiners in the network.
 
         :return: All combiners with info.
@@ -186,15 +137,211 @@ class APIClient:
 
         return _json
 
-    def get_combiner(self, id: str):
-        """ Get a combiner from the statestore.
+    # --- Controller --- #
 
-        :param id: The combiner id to get.
-        :type id: str
-        :return: The combiner info.
+    def get_controller_config(self, checksum=True):
+        """ Get the controller configuration. Optionally include the checksum.
+        The config is used for clients to connect to the controller and ask for combiner assignment.
+
+        :param checksum: Whether to include the checksum of the package.
+        :type checksum: bool
+        :return: The client configuration.
         :rtype: dict
         """
-        response = requests.get(self._get_url_api_v1(f'combiners/{id}'), verify=self.verify, headers=self.headers)
+        response = requests.get(self._get_url('get_client_config'), params={'checksum': checksum}, verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_controller_status(self):
+        """ Get the status of the controller.
+
+        :return: The status of the controller.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url('get_controller_status'), verify=self.verify, headers=self.headers)
+        
+        _json = response.json()
+
+        return _json
+
+    # --- Models --- #
+
+    def get_model(self, id: str):
+        """ Get a model from the statestore.
+
+        :param id: The model id to get.
+        :type id: str
+        :return: The model info.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'models/{id}'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_models(self, session_id: str = None, n_max: int = None):
+        """ Get all models from the statestore.
+
+        :return: All models.
+        :rtype: dict
+        """
+        _params = {}
+
+        if session_id:
+            _params['session_id'] = session_id
+
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers['X-Limit'] = str(n_max)
+
+        response = requests.get(self._get_url_api_v1('models'), params=_params, verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_active_model(self):
+        """ Get the latest model from the statestore.
+
+        :return: The latest model id.
+        :rtype: dict
+        """
+        _headers = self.headers.copy()
+        _headers['X-Limit'] = "1"
+
+        response = requests.get(self._get_url_api_v1('models'), verify=self.verify, headers=_headers)
+        _json = response.json()
+
+        if "result" in _json and len(_json["result"]) > 0:
+            return _json["result"][0]
+
+        return _json
+
+    def get_model_trail(self, id: str = None, n_max: int = None):
+        """ Get the model trail.
+
+        :return: The model trail as dict including commit timestamp.
+        :rtype: dict
+        """
+        if not id:
+            model = self.get_latest_model()
+            if "id" in model:
+                id = model["id"]
+            else:
+                return model
+
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers['X-Limit'] = str(n_max)
+
+        response = requests.get(self._get_url_api_v1(f'models/{id}/ancestors'), verify=self.verify, headers=self.headers)
+        _json = response.json()
+
+        return _json
+
+    def set_model(self, path):
+        """ Set the initial model in the statestore and upload to model repository.
+
+        :param path: The file path of the initial model to set.
+        :type path: str
+        :return: A dict with success or failure message.
+        :rtype: dict
+        """
+        with open(path, 'rb') as file:
+            response = requests.post(self._get_url('set_initial_model'), files={'file': file}, verify=self.verify, headers=self.headers)
+        return response.json()
+
+    # --- Packages --- #
+
+    def get_package(self, id: str):
+        """ Get a compute package from the statestore.
+
+        :param id: The compute package id to get.
+        :type id: str
+        :return: The compute package with info.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'packages/{id}'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_packages(self, n_max: int = None):
+        """ Get all compute packages from the statestore.
+
+        :return: All compute packages with info.
+        :rtype: dict
+        """
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers['X-Limit'] = str(n_max)
+
+        response = requests.get(self._get_url_api_v1('packages'), verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_active_package(self):
+        """ Get the compute package from the statestore.
+
+        :return: The compute package with info.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('packages/active'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_package_checksum(self):
+        """ Get the checksum of the compute package.
+
+        :return: The checksum.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url('get_package_checksum'), verify=self.verify, headers=self.headers)
+        
+        _json = response.json()
+
+        return _json
+
+    def download_package(self, path: str):
+        """ Download the compute package.
+
+        :param path: The path to download the compute package to.
+        :type path: str
+        :return: Message with success or failure.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url('download_package'), verify=self.verify, headers=self.headers)
+        if response.status_code == 200:
+            with open(path, 'wb') as file:
+                file.write(response.content)
+            return {'success': True, 'message': 'Package downloaded successfully.'}
+        else:
+            return {'success': False, 'message': 'Failed to download package.'}
+
+    def set_package(self, path: str, helper: str, name: str = None, description: str = None):
+        """ Set the compute package in the statestore.
+
+        :param path: The file path of the compute package to set.
+        :type path: str
+        :param helper: The helper type to use.
+        :type helper: str
+        :return: A dict with success or failure message.
+        :rtype: dict
+        """
+        with open(path, 'rb') as file:
+            response = requests.post(self._get_url('set_package'), files={'file': file}, data={
+                                     'helper': helper, 'name': name, 'description': description}, verify=self.verify, headers=self.headers)
 
         _json = response.json()
 
@@ -202,7 +349,21 @@ class APIClient:
 
     # --- Rounds --- #
 
-    def list_rounds(self, n_max: int = None):
+    def get_round(self, id: str):
+        """ Get a round from the statestore.
+
+        :param round_id: The round id to get.
+        :type round_id: str
+        :return: The round config and metrics.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'rounds/{id}'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_rounds(self, n_max: int = None):
         """ Get all rounds from the statestore.
 
         :return: All rounds with config and metrics.
@@ -219,21 +380,65 @@ class APIClient:
 
         return _json
 
-    def get_round(self, id: str):
-        """ Get a round from the statestore.
+    # --- Sessions --- #
 
-        :param round_id: The round id to get.
-        :type round_id: str
-        :return: The round config and metrics.
+    def get_session(self, id: str):
+        """ Get a session from the statestore.
+
+        :param id: The session id to get.
+        :type id: str
+        :return: The session as a json object.
         :rtype: dict
         """
-        response = requests.get(self._get_url_api_v1(f'rounds/{id}'), verify=self.verify, headers=self.headers)
+
+        response = requests.get(self._get_url_api_v1(f'sessions/{id}'), self.verify, headers=self.headers)
 
         _json = response.json()
 
         return _json
 
-    # --- Sessions --- #
+    def get_sessions(self, n_max: int = None):
+        """ Get all sessions from the statestore.
+
+        :return: All sessions in dict.
+        :rtype: dict
+        """
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers['X-Limit'] = str(n_max)
+
+        response = requests.get(self._get_url_api_v1('sessions'), verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_session_status(self, id: str):
+        """ Check if a session with id id has finished.
+
+        :param id: The session id to get.
+        :type id: str
+        :return: The session as a json object.
+        :rtype: dict
+        """
+        session = self.get_session(id)
+
+        if session and "status" in session:
+            return session["status"]
+
+        return "Could not retrieve session status."
+
+    def get_session_is_finished(self, id: str):
+        """ Check if a session with id id has finished.
+
+        :param id: The session id to get.
+        :type id: str
+        :return: The session as a json object.
+        :rtype: dict
+        """
+        status = self.get_session_status(id)
+        return status and status.lower() == "finished"
 
     def start_session(self, id: str = None, aggregator: str = 'fedavg', model_id:  str = None, round_timeout: int = 180, rounds: int = 5, round_buffer_size: int = -1, delete_models: bool = True,
                       validate: bool = True, helper: str = 'numpyhelper', min_clients: int = 1, requested_clients: int = 8):
@@ -282,161 +487,23 @@ class APIClient:
 
         return _json
 
-    def list_sessions(self, n_max: int = None):
-        """ Get all sessions from the statestore.
+    # --- Statuses --- #
 
-        :return: All sessions in dict.
-        :rtype: dict
-        """
-        _headers = self.headers.copy()
+    def get_status(self, id: str):
+        """ Get an event from the statestore.
 
-        if n_max:
-            _headers['X-Limit'] = str(n_max)
-        
-        response = requests.get(self._get_url_api_v1('sessions'), verify=self.verify, headers=_headers)
-
-        _json = response.json()
-
-        return _json
-
-    def get_session(self, id: str):
-        """ Get a session from the statestore.
-
-        :param id: The session id to get.
+        :param id: The event id to get.
         :type id: str
-        :return: The session as a json object.
+        :return: The event in dict.
         :rtype: dict
         """
-
-        response = requests.get(self._get_url_api_v1(f'sessions/{id}'), self.verify, headers=self.headers)
+        response = requests.get(self._get_url_api_v1(f'statuses/{id}'), verify=self.verify, headers=self.headers)
 
         _json = response.json()
 
         return _json
 
-    def get_session_status(self, id: str):
-        """ Check if a session with id id has finished.
-
-        :param id: The session id to get.
-        :type id: str
-        :return: The session as a json object.
-        :rtype: dict
-        """
-        session = self.get_session(id)
-        
-        if session and "status" in session:
-            return session["status"]
-
-        return "Could not retrieve session status."
-
-    def session_is_finished(self, id: str):
-        """ Check if a session with id id has finished.
-
-        :param id: The session id to get.
-        :type id: str
-        :return: The session as a json object.
-        :rtype: dict
-        """
-        status = self.get_session_status(id)
-        return status and status.lower() == "finished"
-
-    # --- Packages --- #
-
-    def set_package(self, path: str, helper: str, name: str = None, description: str = None):
-        """ Set the compute package in the statestore.
-
-        :param path: The file path of the compute package to set.
-        :type path: str
-        :param helper: The helper type to use.
-        :type helper: str
-        :return: A dict with success or failure message.
-        :rtype: dict
-        """
-        with open(path, 'rb') as file:
-            response = requests.post(self._get_url('set_package'), files={'file': file}, data={
-                                     'helper': helper, 'name': name, 'description': description}, verify=self.verify, headers=self.headers)
-        return response.json()
-
-    def get_package(self):
-        """ Get the compute package from the statestore.
-
-        :return: The compute package with info.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url_api_v1('packages/active'), verify=self.verify, headers=self.headers)
-
-        _json = response.json()
-
-        return _json
-
-    def list_compute_packages(self, n_max: int = None):
-        """ Get all compute packages from the statestore.
-
-        :return: All compute packages with info.
-        :rtype: dict
-        """
-        _headers = self.headers.copy()
-
-        if n_max:
-            _headers['X-Limit'] = str(n_max)
-
-        response = requests.get(self._get_url_api_v1('packages'), verify=self.verify, headers=_headers)
-        
-        _json = response.json()
-
-        return _json
-
-    def download_package(self, path: str):
-        """ Download the compute package.
-
-        :param path: The path to download the compute package to.
-        :type path: str
-        :return: Message with success or failure.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url('download_package'), verify=self.verify, headers=self.headers)
-        if response.status_code == 200:
-            with open(path, 'wb') as file:
-                file.write(response.content)
-            return {'success': True, 'message': 'Package downloaded successfully.'}
-        else:
-            return {'success': False, 'message': 'Failed to download package.'}
-
-    def get_package_checksum(self):
-        """ Get the checksum of the compute package.
-
-        :return: The checksum.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url('get_package_checksum'), verify=self.verify, headers=self.headers)
-        return response.json()
-
-    def get_client_config(self, checksum=True):
-        """ Get the controller configuration. Optionally include the checksum.
-        The config is used for clients to connect to the controller and ask for combiner assignment.
-
-        :param checksum: Whether to include the checksum of the package.
-        :type checksum: bool
-        :return: The client configuration.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url('get_client_config'), params={'checksum': checksum}, verify=self.verify, headers=self.headers)
-        return response.json()
-
-    # --- Controller --- #
-
-    def get_controller_status(self):
-        """ Get the status of the controller.
-
-        :return: The status of the controller.
-        :rtype: dict
-        """
-        response = requests.get(self._get_url('get_controller_status'), verify=self.verify, headers=self.headers)
-        return response.json()
-
-    # --- Events --- #
-
-    def get_events(self, session_id: str = None, event_type: str = None, sender_name: str = None, sender_role: str = None, n_max: int = None):
+    def get_statuses(self, session_id: str = None, event_type: str = None, sender_name: str = None, sender_role: str = None, n_max: int = None):
         """ Get the events from the statestore. Pass kwargs to filter events.
 
         :return: The events in dict
@@ -469,8 +536,22 @@ class APIClient:
 
     # --- Validations --- #
 
-    def list_validations(
-        self, 
+    def get_validation(self, id: str):
+        """ Get a validation from the statestore.
+
+        :param id: The validation id to get.
+        :type id: str
+        :return: The validation in dict.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1(f'validations/{id}'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_validations(
+        self,
         session_id: str = None,
         model_id: str = None,
         correlation_id: str = None,

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -54,7 +54,7 @@ class APIClient:
 
         :param id: The client id to get.
         :type id: str
-        :return: The client info.
+        :return: Client.
         :rtype: dict
         """
         response = requests.get(self._get_url_api_v1(f'clients/{id}'), verify=self.verify, headers=self.headers)
@@ -64,9 +64,11 @@ class APIClient:
         return _json
 
     def get_clients(self, n_max: int = None):
-        """ Get all clients from the statestore.
+        """ Get clients from the statestore.
 
-        return: All clients.
+        :param n_max: The maximum number of clients to get (If none all will be fetched).
+        :type n_max: int
+        return: Clients.
         rtype: dict
         """
         _headers = self.headers.copy()
@@ -80,12 +82,33 @@ class APIClient:
 
         return _json
 
+    def get_client_config(self, checksum=True):
+        """ Get client config from controller. Optionally include the checksum.
+        The config is used for clients to connect to the controller and ask for combiner assignment.
+
+        :param checksum: Whether to include the checksum of the package.
+        :type checksum: bool
+        :return: The client configuration.
+        :rtype: dict
+        """
+        _params = {
+            'checksum': "true" if checksum else "false"
+        }
+
+        response = requests.get(self._get_url('get_client_config'), params=_params, verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
     def get_active_clients(self, combiner_id: str = None, n_max: int = None):
-        """ Get all active clients from the statestore.
+        """ Get active clients from the statestore.
 
         :param combiner_id: The combiner id to get active clients for.
         :type combiner_id: str
-        :return: All active clients.
+        :param n_max: The maximum number of clients to get (If none all will be fetched).
+        :type n_max: int
+        :return: Active clients.
         :rtype: dict
         """
         _params = {"status": "online"}
@@ -111,7 +134,7 @@ class APIClient:
 
         :param id: The combiner id to get.
         :type id: str
-        :return: The combiner info.
+        :return: Combiner.
         :rtype: dict
         """
         response = requests.get(self._get_url_api_v1(f'combiners/{id}'), verify=self.verify, headers=self.headers)
@@ -121,9 +144,11 @@ class APIClient:
         return _json
 
     def get_combiners(self, n_max: int = None):
-        """ Get all combiners in the network.
+        """ Get combiners in the network.
 
-        :return: All combiners with info.
+        :param n_max: The maximum number of combiners to get (If none all will be fetched).
+        :type n_max: int
+        :return: Combiners.
         :rtype: dict
         """
         _headers = self.headers.copy()
@@ -137,26 +162,7 @@ class APIClient:
 
         return _json
 
-    # --- Controller --- #
-
-    def get_controller_config(self, checksum=True):
-        """ Get the controller configuration. Optionally include the checksum.
-        The config is used for clients to connect to the controller and ask for combiner assignment.
-
-        :param checksum: Whether to include the checksum of the package.
-        :type checksum: bool
-        :return: The client configuration.
-        :rtype: dict
-        """
-        _params = {
-            'checksum': "true" if checksum else "false"
-        }
-
-        response = requests.get(self._get_url('get_client_config'), params=_params, verify=self.verify, headers=self.headers)
-
-        _json = response.json()
-
-        return _json
+    # --- Controllers --- #
 
     def get_controller_status(self):
         """ Get the status of the controller.
@@ -175,9 +181,9 @@ class APIClient:
     def get_model(self, id: str):
         """ Get a model from the statestore.
 
-        :param id: The model id to get.
+        :param id: The id (or model property) of the model to get.
         :type id: str
-        :return: The model info.
+        :return: Model.
         :rtype: dict
         """
         response = requests.get(self._get_url_api_v1(f'models/{id}'), verify=self.verify, headers=self.headers)
@@ -187,8 +193,12 @@ class APIClient:
         return _json
 
     def get_models(self, session_id: str = None, n_max: int = None):
-        """ Get all models from the statestore.
+        """ Get models from the statestore.
 
+        :param session_id: The session id to get models for. (optional)
+        :type session_id: str
+        :param n_max: The maximum number of models to get (If none all will be fetched).
+        :type n_max: int
         :return: All models.
         :rtype: dict
         """
@@ -211,7 +221,7 @@ class APIClient:
     def get_active_model(self):
         """ Get the latest model from the statestore.
 
-        :return: The latest model id.
+        :return: The latest model.
         :rtype: dict
         """
         _headers = self.headers.copy()
@@ -228,7 +238,7 @@ class APIClient:
     def get_model_parameters(self, id: str):
         """ Get the parameters of a model.
 
-        :param id: The model id to get parameters for.
+        :param id: The id (or model property) of the model to get parameters for.
         :type id: str
         :return: The parameters of the model.
         :rtype: dict
@@ -242,7 +252,11 @@ class APIClient:
     def get_model_trail(self, id: str = None, n_max: int = None):
         """ Get the model trail.
 
-        :return: The model trail as dict including commit timestamp.
+        :param id: The id (or model property) of the model to start the trail from. (optional)
+        :type id: str
+        :param n_max: The maximum number of models to get (If none all will be fetched).
+        :type n_max: int
+        :return: List of models.
         :rtype: dict
         """
         if not id:
@@ -265,7 +279,7 @@ class APIClient:
     def download_model(self, id: str, path: str):
         """ Download the model with id id.
 
-        :param id: The model id to download.
+        :param id: The id (or model property) of the model to download.
         :type id: str
         :param path: The path to download the model to.
         :type path: str

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -434,20 +434,87 @@ class APIClient:
         response = requests.get(self._get_url('get_controller_status'), verify=self.verify, headers=self.headers)
         return response.json()
 
-    def get_events(self, **kwargs):
+    # --- Events --- #
+
+    def get_events(self, session_id: str = None, event_type: str = None, sender_name: str = None, sender_role: str = None, n_max: int = None):
         """ Get the events from the statestore. Pass kwargs to filter events.
 
         :return: The events in dict
         :rtype: dict
         """
-        response = requests.get(self._get_url('get_events'), params=kwargs, verify=self.verify, headers=self.headers)
-        return response.json()
+        _params = {}
 
-    def list_validations(self, **kwargs):
+        if session_id:
+            _params["session_id"] = session_id
+
+        if event_type:
+            _params["type"] = event_type
+
+        if sender_name:
+            _params["sender.name"] = sender_name
+
+        if sender_role:
+            _params["sender.role"] = sender_role
+
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers['X-Limit'] = str(n_max)        
+
+        response = requests.get(self._get_url_api_v1('statuses'), params=_params, verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    # --- Validations --- #
+
+    def list_validations(
+        self, 
+        session_id: str = None,
+        model_id: str = None,
+        correlation_id: str = None,
+        sender_name: str = None,
+        sender_role: str = None,
+        receiver_name: str = None,
+        receiver_role: str = None,
+        n_max: int = None
+    ):
         """ Get all validations from the statestore. Pass kwargs to filter validations.
 
         :return: All validations in dict.
         :rtype: dict
         """
-        response = requests.get(self._get_url('list_validations'), params=kwargs, verify=self.verify, headers=self.headers)
-        return response.json()
+        _params = {}
+
+        if session_id:
+            _params["session_id"] = session_id
+
+        if model_id:
+            _params["model_id"] = model_id
+
+        if correlation_id:
+            _params["correlation_id"] = correlation_id
+
+        if sender_name:
+            _params["sender.name"] = sender_name
+        
+        if sender_role:
+            _params["sender.role"] = sender_role
+        
+        if receiver_name:
+            _params["receiver.name"] = receiver_name
+        
+        if receiver_role:
+            _params["receiver.role"] = receiver_role
+
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers['X-Limit'] = str(n_max)
+
+        response = requests.get(self._get_url_api_v1('validations'), params=_params, verify=self.verify, headers=_headers)
+        
+        _json = response.json()
+
+        return _json

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -82,6 +82,18 @@ class APIClient:
 
         return _json
 
+    def get_clients_count(self):
+        """ Get the number of clients in the statestore.
+
+        :return: The number of clients.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('clients/count'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
     def get_client_config(self, checksum=True):
         """ Get client config from controller. Optionally include the checksum.
         The config is used for clients to connect to the controller and ask for combiner assignment.
@@ -157,6 +169,18 @@ class APIClient:
             _headers['X-Limit'] = str(n_max)
 
         response = requests.get(self._get_url_api_v1('combiners'), verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_combiners_count(self):
+        """ Get the number of combiners in the statestore.
+
+        :return: The number of combiners.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('combiners/count'), verify=self.verify, headers=self.headers)
 
         _json = response.json()
 
@@ -311,7 +335,7 @@ class APIClient:
         else:
             return {'success': False, 'message': 'Failed to download model.'}
 
-    def set_model(self, path):
+    def set_active_model(self, path):
         """ Set the initial model in the statestore and upload to model repository.
 
         :param path: The file path of the initial model to set.
@@ -353,6 +377,18 @@ class APIClient:
             _headers['X-Limit'] = str(n_max)
 
         response = requests.get(self._get_url_api_v1('packages'), verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_packages_count(self):
+        """ Get the number of compute packages in the statestore.
+
+        :return: The number of packages.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('packages/count'), verify=self.verify, headers=self.headers)
 
         _json = response.json()
 
@@ -451,6 +487,18 @@ class APIClient:
 
         return _json
 
+    def get_rounds_count(self):
+        """ Get the number of rounds in the statestore.
+
+        :return: The number of rounds.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('rounds/count'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
     # --- Sessions --- #
 
     def get_session(self, id: str):
@@ -482,6 +530,18 @@ class APIClient:
             _headers['X-Limit'] = str(n_max)
 
         response = requests.get(self._get_url_api_v1('sessions'), verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_sessions_count(self):
+        """ Get the number of sessions in the statestore.
+
+        :return: The number of sessions.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('sessions/count'), verify=self.verify, headers=self.headers)
 
         _json = response.json()
 
@@ -625,6 +685,18 @@ class APIClient:
 
         return _json
 
+    def get_statuses_count(self):
+        """ Get the number of statuses in the statestore.
+
+        :return: The number of statuses.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('statuses/count'), verify=self.verify, headers=self.headers)
+
+        _json = response.json()
+
+        return _json
+
     # --- Validations --- #
 
     def get_validation(self, id: str):
@@ -702,6 +774,18 @@ class APIClient:
             _headers['X-Limit'] = str(n_max)
 
         response = requests.get(self._get_url_api_v1('validations'), params=_params, verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def get_validations_count(self):
+        """ Get the number of validations in the statestore.
+
+        :return: The number of validations.
+        :rtype: dict
+        """
+        response = requests.get(self._get_url_api_v1('validations/count'), verify=self.verify, headers=self.headers)
 
         _json = response.json()
 

--- a/fedn/fedn/network/api/client.py
+++ b/fedn/fedn/network/api/client.py
@@ -199,7 +199,7 @@ class APIClient:
         :type session_id: str
         :param n_max: The maximum number of models to get (If none all will be fetched).
         :type n_max: int
-        :return: All models.
+        :return: Models.
         :rtype: dict
         """
         _params = {}
@@ -256,7 +256,7 @@ class APIClient:
         :type id: str
         :param n_max: The maximum number of models to get (If none all will be fetched).
         :type n_max: int
-        :return: List of models.
+        :return: Models.
         :rtype: dict
         """
         if not id:
@@ -313,9 +313,9 @@ class APIClient:
     def get_package(self, id: str):
         """ Get a compute package from the statestore.
 
-        :param id: The compute package id to get.
+        :param id: The id of the compute package to get.
         :type id: str
-        :return: The compute package with info.
+        :return: Package.
         :rtype: dict
         """
         response = requests.get(self._get_url_api_v1(f'packages/{id}'), verify=self.verify, headers=self.headers)
@@ -325,9 +325,11 @@ class APIClient:
         return _json
 
     def get_packages(self, n_max: int = None):
-        """ Get all compute packages from the statestore.
+        """ Get compute packages from the statestore.
 
-        :return: All compute packages with info.
+        :param n_max: The maximum number of packages to get (If none all will be fetched).
+        :type n_max: int
+        :return: Packages.
         :rtype: dict
         """
         _headers = self.headers.copy()
@@ -342,9 +344,9 @@ class APIClient:
         return _json
 
     def get_active_package(self):
-        """ Get the compute package from the statestore.
+        """ Get the (active) compute package from the statestore.
 
-        :return: The compute package with info.
+        :return: Package.
         :rtype: dict
         """
         response = requests.get(self._get_url_api_v1('packages/active'), verify=self.verify, headers=self.headers)
@@ -360,7 +362,7 @@ class APIClient:
         :rtype: dict
         """
         response = requests.get(self._get_url('get_package_checksum'), verify=self.verify, headers=self.headers)
-        
+
         _json = response.json()
 
         return _json
@@ -406,7 +408,7 @@ class APIClient:
 
         :param round_id: The round id to get.
         :type round_id: str
-        :return: The round config and metrics.
+        :return: Round (config and metrics).
         :rtype: dict
         """
         response = requests.get(self._get_url_api_v1(f'rounds/{id}'), verify=self.verify, headers=self.headers)
@@ -418,7 +420,9 @@ class APIClient:
     def get_rounds(self, n_max: int = None):
         """ Get all rounds from the statestore.
 
-        :return: All rounds with config and metrics.
+        :param n_max: The maximum number of rounds to get (If none all will be fetched).
+        :type n_max: int
+        :return: Rounds.
         :rtype: dict
         """
         _headers = self.headers.copy()
@@ -439,7 +443,7 @@ class APIClient:
 
         :param id: The session id to get.
         :type id: str
-        :return: The session as a json object.
+        :return: Session.
         :rtype: dict
         """
 
@@ -450,9 +454,11 @@ class APIClient:
         return _json
 
     def get_sessions(self, n_max: int = None):
-        """ Get all sessions from the statestore.
+        """ Get sessions from the statestore.
 
-        :return: All sessions in dict.
+        :param n_max: The maximum number of sessions to get (If none all will be fetched).
+        :type n_max: int
+        :return: Sessions.
         :rtype: dict
         """
         _headers = self.headers.copy()
@@ -467,12 +473,12 @@ class APIClient:
         return _json
 
     def get_session_status(self, id: str):
-        """ Check if a session with id id has finished.
+        """ Get the status of a session.
 
-        :param id: The session id to get.
+        :param id: The id of the session to get.
         :type id: str
-        :return: The session as a json object.
-        :rtype: dict
+        :return: The status of the session.
+        :rtype: str
         """
         session = self.get_session(id)
 
@@ -482,12 +488,12 @@ class APIClient:
         return "Could not retrieve session status."
 
     def get_session_is_finished(self, id: str):
-        """ Check if a session with id id has finished.
+        """ Check if a session with id has finished.
 
-        :param id: The session id to get.
+        :param id: The id of the session to get.
         :type id: str
-        :return: The session as a json object.
-        :rtype: dict
+        :return: True if session is finished, otherwise false.
+        :rtype: bool
         """
         status = self.get_session_status(id)
         return status and status.lower() == "finished"
@@ -551,11 +557,11 @@ class APIClient:
     # --- Statuses --- #
 
     def get_status(self, id: str):
-        """ Get an event from the statestore.
+        """ Get a status object (event) from the statestore.
 
-        :param id: The event id to get.
+        :param id: The id of the status to get.
         :type id: str
-        :return: The event in dict.
+        :return: Status.
         :rtype: dict
         """
         response = requests.get(self._get_url_api_v1(f'statuses/{id}'), verify=self.verify, headers=self.headers)
@@ -565,10 +571,19 @@ class APIClient:
         return _json
 
     def get_statuses(self, session_id: str = None, event_type: str = None, sender_name: str = None, sender_role: str = None, n_max: int = None):
-        """ Get the events from the statestore. Pass kwargs to filter events.
+        """ Get statuses from the statestore. Filter by input parameters
 
-        :return: The events in dict
-        :rtype: dict
+        :param session_id: The session id to get statuses for.
+        :type session_id: str
+        :param event_type: The event type to get.
+        :type event_type: str
+        :param sender_name: The sender name to get.
+        :type sender_name: str
+        :param sender_role: The sender role to get.
+        :type sender_role: str
+        :param n_max: The maximum number of statuses to get (If none all will be fetched).
+        :type n_max: int
+        :return: Statuses
         """
         _params = {}
 
@@ -600,9 +615,9 @@ class APIClient:
     def get_validation(self, id: str):
         """ Get a validation from the statestore.
 
-        :param id: The validation id to get.
+        :param id: The id of the validation to get.
         :type id: str
-        :return: The validation in dict.
+        :return: Validation.
         :rtype: dict
         """
         response = requests.get(self._get_url_api_v1(f'validations/{id}'), verify=self.verify, headers=self.headers)
@@ -622,9 +637,25 @@ class APIClient:
         receiver_role: str = None,
         n_max: int = None
     ):
-        """ Get all validations from the statestore. Pass kwargs to filter validations.
+        """ Get validations from the statestore. Filter by input parameters.
 
-        :return: All validations in dict.
+        :param session_id: The session id to get validations for.
+        :type session_id: str
+        :param model_id: The model id to get validations for.
+        :type model_id: str
+        :param correlation_id: The correlation id to get validations for.
+        :type correlation_id: str
+        :param sender_name: The sender name to get validations for.
+        :type sender_name: str
+        :param sender_role: The sender role to get validations for.
+        :type sender_role: str
+        :param receiver_name: The receiver name to get validations for.
+        :type receiver_name: str
+        :param receiver_role: The receiver role to get validations for.
+        :type receiver_role: str
+        :param n_max: The maximum number of validations to get (If none all will be fetched).
+        :type n_max: int
+        :return: Validations.
         :rtype: dict
         """
         _params = {}
@@ -640,13 +671,13 @@ class APIClient:
 
         if sender_name:
             _params["sender.name"] = sender_name
-        
+
         if sender_role:
             _params["sender.role"] = sender_role
-        
+
         if receiver_name:
             _params["receiver.name"] = receiver_name
-        
+
         if receiver_role:
             _params["receiver.role"] = receiver_role
 
@@ -656,7 +687,7 @@ class APIClient:
             _headers['X-Limit'] = str(n_max)
 
         response = requests.get(self._get_url_api_v1('validations'), params=_params, verify=self.verify, headers=_headers)
-        
+
         _json = response.json()
 
         return _json

--- a/fedn/fedn/network/api/server.py
+++ b/fedn/fedn/network/api/server.py
@@ -411,7 +411,8 @@ def get_client_config():
     return: The client configuration as a json object.
     rtype: json
     """
-    checksum = request.args.get("checksum", True)
+    checksum_arg = request.args.get("checksum", "true")
+    checksum = checksum_arg.lower() != "false"
     return api.get_client_config(checksum)
 
 

--- a/fedn/fedn/network/api/v1/model_routes.py
+++ b/fedn/fedn/network/api/v1/model_routes.py
@@ -576,9 +576,7 @@ def get_parameters(id: str):
             for i in range(len(a.files)):
                 weights.append(a[str(i)].tolist())
 
-            response = {"weights": weights}
-
-            return jsonify(response), 200
+            return jsonify(array=weights), 200
         else:
             return jsonify({"message": "No model storage configured"}), 500
     except EntityNotFound as e:

--- a/fedn/fedn/network/api/v1/model_routes.py
+++ b/fedn/fedn/network/api/v1/model_routes.py
@@ -3,8 +3,8 @@ import io
 import numpy as np
 from flask import Blueprint, jsonify, request, send_file
 
-from fedn.network.api.v1.shared import (api_version, get_limit, get_reverse,
-                                        get_post_data_to_kwargs,
+from fedn.network.api.v1.shared import (api_version, get_limit,
+                                        get_post_data_to_kwargs, get_reverse,
                                         get_typed_list_headers, mdb,
                                         modelstorage_config)
 from fedn.network.storage.s3.base import RepositoryBase

--- a/fedn/fedn/network/api/v1/shared.py
+++ b/fedn/fedn/network/api/v1/shared.py
@@ -33,6 +33,13 @@ def get_limit(headers: object) -> int:
     return 0
 
 
+def get_reverse(headers: object) -> bool:
+    reverse: str = headers.get("X-Reverse")
+    if reverse and reverse.lower() == "true":
+        return True
+    return False
+
+
 def get_skip(headers: object) -> int:
     skip: str | None = headers.get("X-Skip")
     if is_positive_integer(skip):

--- a/fedn/fedn/network/storage/statestore/stores/model_store.py
+++ b/fedn/fedn/network/storage/statestore/stores/model_store.py
@@ -136,7 +136,7 @@ class ModelStore(Store[Model]):
 
         return result
 
-    def list_ancestors(self, id: str, limit: int, use_typing: bool = False) -> List[Model]:
+    def list_ancestors(self, id: str, limit: int, include_self: bool = False, reverse: bool = False, use_typing: bool = False) -> List[Model]:
         """List ancestors
         param id: The id of the entity
             type: str
@@ -162,6 +162,10 @@ class ModelStore(Store[Model]):
         current_model_id: str = model["parent_model"]
         result: list = []
 
+        if include_self:
+            formatted_model = Model.from_dict(model) if use_typing else from_document(model)
+            result.append(formatted_model)
+
         for _ in range(limit):
             if current_model_id is None:
                 break
@@ -174,6 +178,9 @@ class ModelStore(Store[Model]):
                 current_model_id = model["parent_model"]
             else:
                 break
+
+        if reverse:
+            result.reverse()
 
         return result
 


### PR DESCRIPTION
# Refactor APIClient

_The api client has been refactored and a couple of new methods has been added. Some methods and parameters has been renamed for consistency. All list_* methods has ben renamed to get_* (plural). All get methods has been refactored to use the new api (/api/v1)_

### Interface after update:

**Clients**
- get_client
- get_clients
- get_client_config
- get_active_clients

**Combiners**
- get_combiner
- get_combiners

**Controllers**
- get_controller_status

**Models**
- get_model
- get_models
- get_active_model (renamed from get_latest_model)
- get_model_trail
- download_model (added)
- set_active_model

**Packages**
- get_package
- get_packages
- get_active_package
- get_package_checksum
- download_package
- set_active_package

**Rounds**
- get_round
- get_rounds

**Sessions**
- get_session
- get_sessions
- get_session_status (added)
- session_is_finished
- start_session

**Statuses**
- get_status (added)
- get_statuses (renamed from get events)

**Validations**
- get_validation (added)
- get_validations