### PR TITLE
Bugfix/SK-737 | Conflict in auth metadata in grpc client

### DIFF
--- a/fedn/fedn/network/api/server.py
+++ b/fedn/fedn/network/api/server.py
@@ -427,7 +427,7 @@ if custom_url_prefix:
 
 
 @app.route("/get_package_checksum", methods=["GET"])
-@jwt_auth_required(role="admin")
+@jwt_auth_required(role="client")
 def get_package_checksum():
     name = request.args.get("name", None)
     return api.get_checksum(name)


### PR DESCRIPTION
authorization metadata with token was added both by the metadata plugin as well as manually in each grpc stub call. 

A secure channel must be used to make use of token authentication. If one would like to use an insecure channel (without TLS/SSL) but still have token authentication, then one has to modify the client and use self._add_grpc_metadata("authorization", self.token) 