### PR TITLE
Bug/SK-750 | get_events returns incorrect data if used with custom prefix

### DIFF
--- a/fedn/fedn/network/api/server.py
+++ b/fedn/fedn/network/api/server.py
@@ -560,7 +560,7 @@ def get_events():
 
 
 if custom_url_prefix:
-    app.add_url_rule(f"{custom_url_prefix}/get_events", view_func=get_client_config, methods=["GET"])
+    app.add_url_rule(f"{custom_url_prefix}/get_events", view_func=get_events, methods=["GET"])
 
 
 @app.route("/list_validations", methods=["GET"])


### PR DESCRIPTION
view_func=get_client_config => view_func=get_events for get_events