### PR TITLE
Bugfix/SK-846

### DIFF
--- a/fedn/network/combiner/combiner.py
+++ b/fedn/network/combiner/combiner.py
@@ -326,7 +326,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
                 if status != "online":
                     self.clients[client]["status"] = "online"
                     clients["update_active_clients"].append(client)
-            elif status == "online":
+            elif status == "online" or status == "available":
                 self.clients[client]["status"] = "offline"
                 clients["update_offline_clients"].append(client)
         # Update statestore with client status

--- a/fedn/network/combiner/combiner.py
+++ b/fedn/network/combiner/combiner.py
@@ -326,7 +326,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
                 if status != "online":
                     self.clients[client]["status"] = "online"
                     clients["update_active_clients"].append(client)
-            elif status == "online" or status == "available":
+            elif status != "offline":
                 self.clients[client]["status"] = "offline"
                 clients["update_offline_clients"].append(client)
         # Update statestore with client status


### PR DESCRIPTION
## Description
Status is set to "available" when client is first added. If client disconnects within 10s, the status was never updated to "online" and the status would have then been "available" forever (or until the client connects again).

This PR fixes that issue.