### PR TITLE
bugfix/SK-847 | Fixes timing issue in client status check

### DIFF
--- a/fedn/network/combiner/combiner.py
+++ b/fedn/network/combiner/combiner.py
@@ -337,7 +337,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
         return clients["active_clients"]
 
-    def _deamon_thread_client_status(self, timeout=10):
+    def _deamon_thread_client_status(self, timeout=5):
         """Deamon thread that checks for inactive clients and updates statestore."""
         while True:
             time.sleep(timeout)


### PR DESCRIPTION
## Description
 In TaskStream the client lastseen field is updated if it is older than 10s, and q.get has a timeout of 1s. This means that it could be up to 10.999... seconds between updates in a worst case scenario.

The client status update thread has a period of 10s, and the cutoff for counting a client as active is 10 s. So if you are unlucky, the the timing could be that the client was always seen last more than 10s ago in _list_active_clients (if it happens to always hit that small window between 10s and when the client's "lastseen" is updated), and will thus never be listed as online.

By changing the timeout of _deamon_thread_client_status to 5s, we should have an error of margin and avoid the above issue.