### PR TITLE
bugfix/SK-850 | Sets client status to online in database when client connects

### DIFF
--- a/fedn/network/combiner/combiner.py
+++ b/fedn/network/combiner/combiner.py
@@ -64,7 +64,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
         # Client queues
         self.clients = {}
-        
+
 
         # Validate combiner name
         match = re.search(VALID_NAME_REGEX, config["name"])
@@ -121,7 +121,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         self.repository = Repository(announce_config["storage"]["storage_config"])
 
         self.statestore = MongoStateStore(announce_config["statestore"]["network_id"], announce_config["statestore"]["mongo_config"])
-        
+
         # Fetch all clients previously connected to the combiner
         # If a client and a combiner goes down at the same time,
         # the client will be stuck listed as "online" in the statestore.
@@ -131,7 +131,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
             self.statestore.set_client({"name": client["name"], "status": "offline"})
 
         self.modelservice = ModelService()
-        
+
         # Create gRPC server
         self.server = Server(self, self.modelservice, grpc_config)
 


### PR DESCRIPTION
## Description
If a client disconnects and connects again before combiner registers it as offline, then controller updates status is db to "available", but combiner sees no change and client status is then stuck as "available" in database.

If a client and combiner goes down at a similar time, then the client is always listed as "online" if the combiner didn't have time to register the client disconnecting.

This PR fixes the first issue by setting the db status to online in TaskStream when the client reconnects. It partly addresses the second issue by cleaning up the status of previously connected clients when the combiner comes online again. Of course, if the combiner remains offline, then this issue is still there (could maybe be solved in the controller in that case)?