### PR TITLE
Feature/SK-852 | Add numpy raw binary helper

### DIFF
--- a/fedn/utils/helpers/helperbase.py
+++ b/fedn/utils/helpers/helperbase.py
@@ -1,5 +1,3 @@
-import os
-import tempfile
 from abc import ABC, abstractmethod
 
 

--- a/fedn/utils/helpers/helperbase.py
+++ b/fedn/utils/helpers/helperbase.py
@@ -40,12 +40,3 @@ class HelperBase(ABC):
         :return: Weights in array-like format.
         """
         pass
-
-    def get_tmp_path(self):
-        """Return a temporary output path compatible with save_model, load_model.
-
-        :return: Path to file.
-        """
-        fd, path = tempfile.mkstemp(suffix=".npz")
-        os.close(fd)
-        return path

--- a/fedn/utils/helpers/plugins/binaryhelper.py
+++ b/fedn/utils/helpers/plugins/binaryhelper.py
@@ -1,0 +1,16 @@
+from fedn.utils.helpers.plugins.numpyhelper import Helper
+
+
+class Helper(Helper):
+    """FEDn helper class for models weights/parameters that can be transformed to numpy ndarrays."""
+
+    def __init__(self):
+        """Initialize helper."""
+        super().__init__()
+        self.name = "binaryhelper"
+
+    def load(self, path, file_type="raw_binary"):
+        return super().load(path, file_type)
+
+    def save(self, model, path=None, file_type="raw_binary"):
+        return super().save(model, path, file_type)


### PR DESCRIPTION
The default numpyhelper is based on numpy compressed file format (npz). This PR introduces a new helper that enables raw binary file format (.bin) which will be read using either numpy.frombuffer or numpy.fromfile instead of numpy.load. 

The helper is called "binaryhelper". 