### PR TITLE
Added examples to dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,6 +4,7 @@
 tmp/*
 test/*
 docs/*
+examples/*
 **/.venv
 **/.mnist-keras
 **/.mnist-pytorch


### PR DESCRIPTION
## Description

Makes docker images smaller by avoiding to copy the examples folder to the image during build. 