### PR TITLE
Feature/SK-866 | Inference TaskType workflow

### DIFF
--- a/fedn/network/api/v1/__init__.py
+++ b/fedn/network/api/v1/__init__.py
@@ -1,5 +1,6 @@
 from fedn.network.api.v1.client_routes import bp as client_bp
 from fedn.network.api.v1.combiner_routes import bp as combiner_bp
+from fedn.network.api.v1.inference_routes import bp as inference_bp
 from fedn.network.api.v1.model_routes import bp as model_bp
 from fedn.network.api.v1.package_routes import bp as package_bp
 from fedn.network.api.v1.round_routes import bp as round_bp
@@ -7,4 +8,4 @@ from fedn.network.api.v1.session_routes import bp as session_bp
 from fedn.network.api.v1.status_routes import bp as status_bp
 from fedn.network.api.v1.validation_routes import bp as validation_bp
 
-_routes = [client_bp, combiner_bp, model_bp, package_bp, round_bp, session_bp, status_bp, validation_bp]
+_routes = [client_bp, combiner_bp, model_bp, package_bp, round_bp, session_bp, status_bp, validation_bp, inference_bp]

--- a/fedn/network/api/v1/inference_routes.py
+++ b/fedn/network/api/v1/inference_routes.py
@@ -1,0 +1,39 @@
+import threading
+
+from flask import Blueprint, jsonify, request
+
+from fedn.network.api.auth import jwt_auth_required
+from fedn.network.api.shared import control
+from fedn.network.api.v1.shared import (api_version, get_post_data_to_kwargs,
+                                        get_typed_list_headers, mdb)
+from fedn.network.storage.statestore.stores.session_store import SessionStore
+from fedn.network.storage.statestore.stores.shared import EntityNotFound
+
+from .model_routes import model_store
+
+bp = Blueprint("inference", __name__, url_prefix=f"/api/{api_version}/infer")
+
+
+@bp.route("/start", methods=["POST"])
+@jwt_auth_required(role="admin")
+def start_session():
+    """Start a new inference session.
+    param: session_id: The session id to start.
+    type: session_id: str
+    param: rounds: The number of rounds to run.
+    type: rounds: int
+    """
+    try:
+        data = request.json if request.headers["Content-Type"] == "application/json" else request.form.to_dict()
+        session_id: str = data.get("session_id")
+
+        if not session_id or session_id == "":
+            return jsonify({"message": "Session ID is required"}), 400
+
+        session_config = {"session_id": session_id}
+
+        threading.Thread(target=control.inference_session, kwargs={"config":session_config}).start()
+
+        return jsonify({"message": "Session started"}), 200
+    except Exception as e:
+        return jsonify({"message": str(e)}), 500

--- a/fedn/network/api/v1/inference_routes.py
+++ b/fedn/network/api/v1/inference_routes.py
@@ -4,12 +4,7 @@ from flask import Blueprint, jsonify, request
 
 from fedn.network.api.auth import jwt_auth_required
 from fedn.network.api.shared import control
-from fedn.network.api.v1.shared import (api_version, get_post_data_to_kwargs,
-                                        get_typed_list_headers, mdb)
-from fedn.network.storage.statestore.stores.session_store import SessionStore
-from fedn.network.storage.statestore.stores.shared import EntityNotFound
-
-from .model_routes import model_store
+from fedn.network.api.v1.shared import api_version
 
 bp = Blueprint("inference", __name__, url_prefix=f"/api/{api_version}/infer")
 
@@ -32,8 +27,8 @@ def start_session():
 
         session_config = {"session_id": session_id}
 
-        threading.Thread(target=control.inference_session, kwargs={"config":session_config}).start()
+        threading.Thread(target=control.inference_session, kwargs={"config": session_config}).start()
 
-        return jsonify({"message": "Session started"}), 200
-    except Exception as e:
-        return jsonify({"message": str(e)}), 500
+        return jsonify({"message": "Inference session started"}), 200
+    except Exception:
+        return jsonify({"message": "Failed to start inference session"}), 500

--- a/fedn/network/combiner/aggregators/aggregatorbase.py
+++ b/fedn/network/combiner/aggregators/aggregatorbase.py
@@ -86,9 +86,11 @@ class AggregatorBase(ABC):
         :return: True if the model update is valid, False otherwise.
         :rtype: bool
         """
-        data = json.loads(model_update.meta)["training_metadata"]
-        if "num_examples" not in data.keys():
-            logger.error("AGGREGATOR({}): Model validation failed, num_examples missing in metadata.".format(self.name))
+        try:
+            data = json.loads(model_update.meta)["training_metadata"]
+            num_examples = data["num_examples"]
+        except KeyError as e:
+            logger.error("AGGREGATOR({}): Invalid model update, missing metadata.".format(self.name))
             return False
         return True
 

--- a/fedn/network/combiner/combiner.py
+++ b/fedn/network/combiner/combiner.py
@@ -12,8 +12,7 @@ from enum import Enum
 
 import fedn.network.grpc.fedn_pb2 as fedn
 import fedn.network.grpc.fedn_pb2_grpc as rpc
-from fedn.common.log_config import (logger, set_log_level_from_string,
-                                    set_log_stream)
+from fedn.common.log_config import logger, set_log_level_from_string, set_log_stream
 from fedn.network.combiner.connect import ConnectorCombiner, Status
 from fedn.network.combiner.modelservice import ModelService
 from fedn.network.combiner.roundhandler import RoundConfig, RoundHandler
@@ -65,7 +64,6 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
 
         # Client queues
         self.clients = {}
-
 
         # Validate combiner name
         match = re.search(VALID_NAME_REGEX, config["name"])
@@ -196,7 +194,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         else:
             logger.info("Sent model validation request for model {} to {} clients".format(request.model_id, len(clients)))
 
-    def request_model_inference(self, session_id: str, model_id: str, clients: list=[]) -> None:
+    def request_model_inference(self, session_id: str, model_id: str, clients: list = []) -> None:
         """Ask clients to perform inference on the model.
 
         :param model_id: the model id to perform inference on
@@ -250,7 +248,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
             if len(clients) == 0:
                 # TODO: add inference clients type
                 clients = self.get_active_validators()
-        
+
         # TODO: if inference, request.data should be user-defined data/parameters
 
         for client in clients:

--- a/fedn/network/combiner/interfaces.py
+++ b/fedn/network/combiner/interfaces.py
@@ -8,6 +8,7 @@ import grpc
 
 import fedn.network.grpc.fedn_pb2 as fedn
 import fedn.network.grpc.fedn_pb2_grpc as rpc
+from fedn.network.combiner.roundhandler import RoundConfig
 
 
 class CombinerUnavailableError(Exception):
@@ -202,7 +203,7 @@ class CombinerInterface:
             else:
                 raise
 
-    def submit(self, config):
+    def submit(self, config: RoundConfig):
         """Submit a compute plan to the combiner.
 
         :param config: The job configuration.

--- a/fedn/network/combiner/roundhandler.py
+++ b/fedn/network/combiner/roundhandler.py
@@ -424,7 +424,7 @@ class RoundHandler:
                         elif round_config["task"] == "validation":
                             self.execute_validation_round(session_id, model_id)
                         elif  round_config["task"] == "inference":
-                            logger.info("Inference task not yet implemented.")
+                            self.execute_inference_round(session_id, model_id)
                         else:
                             logger.warning("config contains unkown task type.")
                     else:

--- a/fedn/network/combiner/roundhandler.py
+++ b/fedn/network/combiner/roundhandler.py
@@ -8,15 +8,14 @@ from typing import TypedDict
 
 from fedn.common.log_config import logger
 from fedn.network.combiner.aggregators.aggregatorbase import get_aggregator
-from fedn.network.combiner.modelservice import (load_model_from_BytesIO,
-                                                serialize_model_to_BytesIO)
+from fedn.network.combiner.modelservice import load_model_from_BytesIO, serialize_model_to_BytesIO
 from fedn.utils.helpers.helpers import get_helper
 from fedn.utils.parameters import Parameters
 
 
 class RoundConfig(TypedDict):
     """Round configuration.
-    
+
     :param _job_id: A universally unique identifier for the round. Set by Combiner.
     :type _job_id: str
     :param committed_at: The time the round was committed. Set by Controller.
@@ -47,6 +46,7 @@ class RoundConfig(TypedDict):
     :param aggregator: The aggregator type.
     :type aggregator: str
     """
+
     _job_id: str
     committed_at: str
     task: str
@@ -62,6 +62,8 @@ class RoundConfig(TypedDict):
     session_id: str
     helper_type: str
     aggregator: str
+
+
 class ModelUpdateError(Exception):
     pass
 
@@ -246,7 +248,7 @@ class RoundHandler:
         :type model_id: str
         """
         self.server.request_model_validation(session_id, model_id, clients=clients)
-    
+
     def _inference_round(self, session_id: str, model_id: str, clients: list):
         """Send model inference requests to clients.
 
@@ -346,7 +348,7 @@ class RoundHandler:
         self.stage_model(model_id)
         validators = self._assign_round_clients(self.server.max_clients, type="validators")
         self._validation_round(session_id, model_id, validators)
-    
+
     def execute_inference_round(self, session_id: str, model_id: str) -> None:
         """Coordinate inference rounds as specified in config.
 
@@ -423,7 +425,7 @@ class RoundHandler:
                             self.server.statestore.set_round_combiner_data(round_meta)
                         elif round_config["task"] == "validation":
                             self.execute_validation_round(session_id, model_id)
-                        elif  round_config["task"] == "inference":
+                        elif round_config["task"] == "inference":
                             self.execute_inference_round(session_id, model_id)
                         else:
                             logger.warning("config contains unkown task type.")

--- a/fedn/network/controller/control.py
+++ b/fedn/network/controller/control.py
@@ -202,12 +202,13 @@ class Control(ControlBase):
             logger.warning("Inference round cannot start, no combiners connected!")
             return
         
-        if not config["model_id"]:
+        if not "model_id" in config.keys():
             config["model_id"]= self.statestore.get_latest_model()
         
         config["committed_at"] = datetime.datetime.now()
         config["task"] = "inference"
         config["rounds"] = str(1)
+        config["clients_required"] = 1
 
         participating_combiners = self.get_participating_combiners(config)
 

--- a/fedn/network/controller/control.py
+++ b/fedn/network/controller/control.py
@@ -2,10 +2,8 @@ import copy
 import datetime
 import time
 import uuid
-from typing import TypedDict
 
-from tenacity import (retry, retry_if_exception_type, stop_after_delay,
-                      wait_random)
+from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_random
 
 from fedn.common.log_config import logger
 from fedn.network.combiner.interfaces import CombinerUnavailableError
@@ -185,7 +183,7 @@ class Control(ControlBase):
         # TODO: Report completion of session
         self.set_session_status(config["session_id"], "Finished")
         self._state = ReducerState.idle
-    
+
     def inference_session(self, config: RoundConfig) -> None:
         """Execute a new inference session.
 
@@ -193,7 +191,6 @@ class Control(ControlBase):
         :type config: InferenceConfig
         :return: None
         """
-
         if self._state == ReducerState.instructing:
             logger.info("Controller already in INSTRUCTING state. A session is in progress.")
             return
@@ -201,10 +198,10 @@ class Control(ControlBase):
         if len(self.network.get_combiners()) < 1:
             logger.warning("Inference round cannot start, no combiners connected!")
             return
-        
-        if not "model_id" in config.keys():
-            config["model_id"]= self.statestore.get_latest_model()
-        
+
+        if "model_id" not in config.keys():
+            config["model_id"] = self.statestore.get_latest_model()
+
         config["committed_at"] = datetime.datetime.now()
         config["task"] = "inference"
         config["rounds"] = str(1)
@@ -216,7 +213,7 @@ class Control(ControlBase):
         round_start = self.evaluate_round_start_policy(participating_combiners)
 
         if round_start:
-            logger.info("Inference round start policy met, {} participating combiners.".format(len(participating_combiners)))    
+            logger.info("Inference round start policy met, {} participating combiners.".format(len(participating_combiners)))
             for combiner, _ in participating_combiners:
                 combiner.submit(config)
                 logger.info("Inference round submitted to combiner {}".format(combiner))

--- a/fedn/network/controller/controlbase.py
+++ b/fedn/network/controller/controlbase.py
@@ -114,14 +114,12 @@ class ControlBase(ABC):
             return False
 
     def get_model_info(self):
-        """:return:
-        """
+        """:return:"""
         return self.statestore.get_model_trail()
 
     # TODO: remove use statestore.get_events() instead
     def get_events(self):
-        """:return:
-        """
+        """:return:"""
         return self.statestore.get_events()
 
     def get_latest_round_id(self):
@@ -136,8 +134,7 @@ class ControlBase(ABC):
         return round
 
     def get_compute_package_name(self):
-        """:return:
-        """
+        """:return:"""
         definition = self.statestore.get_compute_package()
         if definition:
             try:
@@ -164,7 +161,7 @@ class ControlBase(ABC):
         else:
             return None
 
-    def create_session(self, config: RoundConfig, status: str="Initialized") -> None:
+    def create_session(self, config: RoundConfig, status: str = "Initialized") -> None:
         """Initialize a new session in backend db."""
         if "session_id" not in config.keys():
             session_id = uuid.uuid4()

--- a/fedn/network/storage/statestore/mongostatestore.py
+++ b/fedn/network/storage/statestore/mongostatestore.py
@@ -6,6 +6,7 @@ import pymongo
 from google.protobuf.json_format import MessageToDict
 
 from fedn.common.log_config import logger
+from fedn.network.combiner.roundhandler import RoundConfig
 from fedn.network.state import ReducerStateToString, StringToReducerState
 
 
@@ -859,7 +860,7 @@ class MongoStateStore:
         # TODO: Add check if round_id already exists
         self.rounds.insert_one(round_data)
 
-    def set_session_config(self, id, config):
+    def set_session_config(self, id: str, config: RoundConfig) -> None:
         """Set the session configuration.
 
         :param id: The session id
@@ -886,7 +887,7 @@ class MongoStateStore:
         """
         self.rounds.update_one({"round_id": str(data["round_id"])}, {"$push": {"combiners": data}}, True)
 
-    def set_round_config(self, round_id, round_config):
+    def set_round_config(self, round_id, round_config: RoundConfig):
         """Set round configuration.
 
         :param round_id: The round unique identifier


### PR DESCRIPTION
introduces a new TaskType and workflow for inference on the server side. 
Currently infernce will work very similar to validation except the number of rounds will only be 1. 

It's up to the client side to respond to the TaskStream when statusType  is of type "INFERENCE".

This PR does not introduce any client side inference actions.