### PR TITLE
Fix/SK-904 | Uncontrolled data used in path expression

### DIFF
--- a/fedn/network/api/interface.py
+++ b/fedn/network/api/interface.py
@@ -1,6 +1,5 @@
 import base64
 import copy
-import os
 import threading
 import uuid
 from io import BytesIO

--- a/fedn/network/api/interface.py
+++ b/fedn/network/api/interface.py
@@ -4,7 +4,8 @@ import threading
 import uuid
 from io import BytesIO
 
-from flask import jsonify, safe_join, send_from_directory
+from flask import jsonify, send_from_directory
+from werkzeug.security import safe_join
 from werkzeug.utils import secure_filename
 
 from fedn.common.config import get_controller_config, get_network_config

--- a/fedn/network/api/interface.py
+++ b/fedn/network/api/interface.py
@@ -232,7 +232,7 @@ class API:
         file_name = file.filename
         storage_file_name = secure_filename(f"{str(uuid.uuid4())}.{extension}")
 
-        file_path = os.path.join("/app/client/package/", storage_file_name)
+        file_path = safe_join("/app/client/package/", storage_file_name)
         file.save(file_path)
 
         self.control.set_compute_package(storage_file_name, file_path)
@@ -399,7 +399,7 @@ class API:
             name, message = self._get_compute_package_name()
             if name is None:
                 return False, message, ""
-        file_path = os.path.join("/app/client/package/", name)  # TODO: make configurable, perhaps in config.py or package.py
+        file_path = safe_join("/app/client/package/", name)  # TODO: make configurable, perhaps in config.py or package.py
         try:
             sum = str(sha(file_path))
         except FileNotFoundError:

--- a/fedn/network/api/interface.py
+++ b/fedn/network/api/interface.py
@@ -5,7 +5,7 @@ import threading
 import uuid
 from io import BytesIO
 
-from flask import jsonify, send_from_directory
+from flask import jsonify, safe_join, send_from_directory
 from werkzeug.utils import secure_filename
 
 from fedn.common.config import get_controller_config, get_network_config
@@ -377,7 +377,7 @@ class API:
             try:
                 data = self.control.get_compute_package(name)
                 # TODO: make configurable, perhaps in config.py or package.py
-                file_path = os.path.join("/app/client/package/", name)
+                file_path = safe_join("/app/client/package/", name)
                 with open(file_path, "wb") as fh:
                     fh.write(data)
                 # TODO: make configurable, perhaps in config.py or package.py


### PR DESCRIPTION
Remove insecure opening of filename from user input. Use flask safe_join.
In furure in v1, don't use user input for filename instead controller use temporary filename for different packages. 