### PR TITLE
Fix/SK-905 | Don't allow v8.4.0 of tenacity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
   "grpcio-health-checking~=1.60.0",
   "pyyaml",
   "plotly",
-  "virtualenv"
+  "virtualenv",
+  "tenacity!=8.4.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
asyncio subpackage is missing in tenacity v8.4.0, fixed in https://github.com/jd/tenacity/releases/tag/8.4.1