### PR TITLE
Feature/SK-911 | Add terminate session to controller

### DIFF
--- a/fedn/network/controller/controlbase.py
+++ b/fedn/network/controller/controlbase.py
@@ -183,6 +183,16 @@ class ControlBase(ABC):
         """
         self.statestore.set_session_status(session_id, status)
 
+    def get_session_status(self, session_id):
+        """Get the status of a session.
+
+        :param session_id: The session unique identifier
+        :type session_id: str
+        :return: The status
+        :rtype: str
+        """
+        return self.statestore.get_session_status(session_id)
+
     def create_round(self, round_data):
         """Initialize a new round in backend db."""
         self.statestore.create_round(round_data)

--- a/fedn/network/storage/statestore/mongostatestore.py
+++ b/fedn/network/storage/statestore/mongostatestore.py
@@ -168,6 +168,17 @@ class MongoStateStore:
         """
         return self.sessions.find_one({"session_id": session_id})
 
+    def get_session_status(self, session_id):
+        """Get the session status.
+
+        :param session_id: The session id.
+        :type session_id: str
+        :return: The session status.
+        :rtype: str
+        """
+        session = self.sessions.find_one({"session_id": session_id})
+        return session["status"]
+
     def set_latest_model(self, model_id, session_id=None):
         """Set the latest model id.
 


### PR DESCRIPTION
Terminate an ongoing session when status is "Terminated". Obs, won't flush queues at combiners or terminate ongoing training or validation requests at clients.

requests.patch("http://localhost:8092/api/v1/sessions/b9fa1b07-fef9-4ddf-a869-a1d43f3c9968", json={"status": "Terminated"})