### PR TITLE
Bug/SK-937 | Update for previous clients fails, missing client_id

### DIFF
--- a/fedn/network/combiner/combiner.py
+++ b/fedn/network/combiner/combiner.py
@@ -127,7 +127,10 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         # Set the status to offline for previous clients.
         previous_clients = self.statestore.clients.find({"combiner": config["name"]})
         for client in previous_clients:
-            self.statestore.set_client({"name": client["name"], "status": "offline", "client_id": client["client_id"]})
+            try:
+                self.statestore.set_client({"name": client["name"], "status": "offline", "client_id": client["client_id"]})
+            except KeyError:
+                self.statestore.set_client({"name": client["name"], "status": "offline"})
 
         self.modelservice = ModelService()
 


### PR DESCRIPTION
Sync from <v0.11 to 0.11 will fail when previous clients miss "cllient_id", raises KeyError. Fix: catch KeyError and update previous clients without "client_id"