### PR TITLE
Docs/SK-973 | Removed CSS rule to unhide bullet points in unordered lists

### DIFF
--- a/docs/_static/css/elements.css
+++ b/docs/_static/css/elements.css
@@ -19,7 +19,6 @@ article ul {
 
 .rst-content .section ul li,
 .rst-content .toctree-wrapper ul li,
-.rst-content section ul li,
 .wy-plain-list-disc li,
 article ul li {
     list-style: none;


### PR DESCRIPTION
* Removed CSS rule that hid bullets points in unordered lists. 
* All unordered lists now have bullet points, like in the readme on Github. 
* This looks good on the "What is Federated Learning?" but might be cluttered on other pages, ex. on the "Using the Python API" page (see before and after images).

![after](https://github.com/user-attachments/assets/2e25486c-0834-4b22-9586-63fa66ffa45c)
![before](https://github.com/user-attachments/assets/57f68fdc-9870-450b-8db3-ef14ab55dc63)
