### PR TITLE
Feature/SK-992 | Update the copyright year of FEDn in the docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright 2021 Scaleout Systems AB.  All rights reserved.
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,7 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # Project info
 project = "FEDn"
-copyright = "2021, Scaleout Systems AB"
+copyright = "2024, Scaleout Systems AB"
 author = "Scaleout Systems AB"
 
 # The full version, including alpha/beta/rc tags

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -8,7 +8,6 @@ sys.path.insert(0, os.path.abspath(".."))
 
 # Project info
 project = "FEDn"
-copyright = "2024, Scaleout Systems AB"
 author = "Scaleout Systems AB"
 
 # The full version, including alpha/beta/rc tags


### PR DESCRIPTION
2021 => 2024