### PR TITLE
Fix/SK-1021 | Updating dependencies for huggingface example

### DIFF
--- a/examples/huggingface/client/python_env.yaml
+++ b/examples/huggingface/client/python_env.yaml
@@ -2,10 +2,10 @@ name: huggingface
 build_dependencies:
   - pip
   - setuptools
-  - wheel==0.37.1
+  - wheel
 dependencies:
-  - torch==2.2.1
-  - torchvision==0.17.1
-  - fedn==0.9.0
-  - transformers==4.39.3
-  - datasets==2.19.0
+  - torch
+  - torchvision
+  - fedn
+  - transformers
+  - datasets


### PR DESCRIPTION
Change in the python_env.yaml file. 

Dependencies (for libaries torch, transformers, ...) now don't specify specific versions anymore.