### PR TITLE
Fix/SK-1025 | Fix torch dependencies based on arch

### DIFF
--- a/examples/FedSimSiam/client/python_env.yaml
+++ b/examples/FedSimSiam/client/python_env.yaml
@@ -4,6 +4,11 @@ build_dependencies:
   - setuptools
   - wheel==0.37.1
 dependencies:
-  - torch==2.2.0
-  - torchvision==0.17.0
-  - fedn==0.9.0
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  # PyTorch macOS x86 builds deprecation
+  - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
+  - fedn

--- a/examples/FedSimSiam/client/python_env.yaml
+++ b/examples/FedSimSiam/client/python_env.yaml
@@ -9,6 +9,7 @@ dependencies:
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
-  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+  - numpy==1.24.4; python_version == "3.8"
   - fedn

--- a/examples/flower-client/client/python_env.yaml
+++ b/examples/flower-client/client/python_env.yaml
@@ -10,7 +10,8 @@ dependencies:
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
-  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+  - numpy==1.24.4; python_version == "3.8"
   - fire==0.3.1
   - flwr-datasets[vision]==0.1.0

--- a/examples/flower-client/client/python_env.yaml
+++ b/examples/flower-client/client/python_env.yaml
@@ -4,8 +4,13 @@ build_dependencies:
   - setuptools
   - wheel==0.37.1
 dependencies:
-  - torch==2.2.1
-  - torchvision==0.17.1
+  - fedn[flower]
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  # PyTorch macOS x86 builds deprecation
+  - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
   - fire==0.3.1
-  - fedn[flower]==0.9.0
   - flwr-datasets[vision]==0.1.0

--- a/examples/huggingface/client/python_env.yaml
+++ b/examples/huggingface/client/python_env.yaml
@@ -4,9 +4,13 @@ build_dependencies:
   - setuptools
   - wheel
 dependencies:
-  - numpy==2.0.2 
-  - torch==2.4.1
-  - torchvision==0.19.1
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  # PyTorch macOS x86 builds deprecation
+  - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
   - transformers
   - datasets
   - fedn

--- a/examples/huggingface/client/python_env.yaml
+++ b/examples/huggingface/client/python_env.yaml
@@ -9,8 +9,9 @@ dependencies:
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
-  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+  - numpy==1.24.4; python_version == "3.8"
   - transformers
   - datasets
   - fedn

--- a/examples/mnist-pytorch-DPSGD/client/python_env.yaml
+++ b/examples/mnist-pytorch-DPSGD/client/python_env.yaml
@@ -5,11 +5,12 @@ build_dependencies:
   - wheel
 dependencies:
   - fedn
-  -  torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
   # PyTorch macOS x86 builds deprecation
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
-  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+  - numpy==1.24.4; python_version == "3.8"
   - opacus

--- a/examples/mnist-pytorch/client/python_env.yaml
+++ b/examples/mnist-pytorch/client/python_env.yaml
@@ -4,6 +4,11 @@ build_dependencies:
   - setuptools
   - wheel
 dependencies:
-  - torch
-  - torchvision
   - fedn
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  # PyTorch macOS x86 builds deprecation
+  - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"

--- a/examples/mnist-pytorch/client/python_env.yaml
+++ b/examples/mnist-pytorch/client/python_env.yaml
@@ -10,5 +10,6 @@ dependencies:
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
-  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+  - numpy==1.24.4; python_version == "3.8"

--- a/examples/monai-2D-mednist/client/python_env.yaml
+++ b/examples/monai-2D-mednist/client/python_env.yaml
@@ -10,7 +10,8 @@ dependencies:
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
-  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+  - numpy==1.24.4; python_version == "3.8"
   - monai-weekly[pillow, tqdm]
   - scikit-learn  

--- a/examples/monai-2D-mednist/client/python_env.yaml
+++ b/examples/monai-2D-mednist/client/python_env.yaml
@@ -4,9 +4,13 @@ build_dependencies:
   - setuptools
   - wheel
 dependencies:
-  - torch==2.2.1
-  - torchvision==0.17.1
   - fedn
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  # PyTorch macOS x86 builds deprecation
+  - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - numpy==1.26.4; sys_platform == "darwin" and platform_machine == "x86_64"
   - monai-weekly[pillow, tqdm]
-  - numpy==1.26.4
   - scikit-learn  

--- a/fedn/network/combiner/shared.py
+++ b/fedn/network/combiner/shared.py
@@ -8,6 +8,6 @@ modelstorage_config = get_modelstorage_config()
 network_id = get_network_config()
 
 statestore = MongoStateStore(network_id, statestore_config["mongo_config"])
-repository = Repository(modelstorage_config["storage_config"])
+repository = Repository(modelstorage_config["storage_config"], init_buckets=False)
 
 modelservice = ModelService()

--- a/fedn/network/storage/s3/repository.py
+++ b/fedn/network/storage/s3/repository.py
@@ -8,7 +8,7 @@ from fedn.network.storage.s3.miniorepository import MINIORepository
 class Repository:
     """Interface for storing model objects and compute packages in S3 compatible storage."""
 
-    def __init__(self, config):
+    def __init__(self, config, init_buckets=True):
         self.model_bucket = config["storage_bucket"]
         self.context_bucket = config["context_bucket"]
         try:
@@ -19,9 +19,10 @@ class Repository:
         # TODO: Make a plug-in solution
         self.client = MINIORepository(config)
 
-        self.client.create_bucket(self.context_bucket)
-        self.client.create_bucket(self.model_bucket)
-        self.client.create_bucket(self.inference_bucket)
+        if init_buckets:
+            self.client.create_bucket(self.context_bucket)
+            self.client.create_bucket(self.model_bucket)
+            self.client.create_bucket(self.inference_bucket)
 
     def get_model(self, model_id):
         """Retrieve a model with id model_id.


### PR DESCRIPTION
We have been facing issues in the dependencies on projects having torch. If the environment uses a x86 (intel) MacOS torch have no support for versions beyond >v2.2.

Even though this is a hardware issue, I have seen people using x86 installed python on the MacOS arm64 (silicon) hardware, which also couses this issue. 

To deal with this I have pinned the versions of torch torchvision and numpy based on environments markers such as sys_platform and platform_machine for all examples depending on torch.