### PR TITLE
Feature/SK-1039 | Add upload, activate & deactivate package to fedn api v1

### DIFF
--- a/fedn/common/config.py
+++ b/fedn/common/config.py
@@ -19,6 +19,8 @@ FEDN_CUSTOM_URL_PREFIX = os.environ.get("FEDN_CUSTOM_URL_PREFIX", "")
 FEDN_ALLOW_LOCAL_PACKAGE = os.environ.get("FEDN_ALLOW_LOCAL_PACKAGE", False)
 FEDN_PACKAGE_EXTRACT_DIR = os.environ.get("FEDN_PACKAGE_EXTRACT_DIR", "package")
 
+FEDN_COMPUTE_PACKAGE_DIR = os.environ.get("FEDN_COMPUTE_PACKAGE_DIR", "/app/client/package/")
+
 
 def get_environment_config():
     """Get the configuration from environment variables."""

--- a/fedn/network/api/interface.py
+++ b/fedn/network/api/interface.py
@@ -7,7 +7,7 @@ from flask import jsonify, send_from_directory
 from werkzeug.security import safe_join
 from werkzeug.utils import secure_filename
 
-from fedn.common.config import FEDN_ALLOW_LOCAL_PACKAGE, get_controller_config, get_network_config
+from fedn.common.config import FEDN_ALLOW_LOCAL_PACKAGE, FEDN_COMPUTE_PACKAGE_DIR, get_controller_config, get_network_config
 from fedn.common.log_config import logger
 from fedn.network.combiner.interfaces import CombinerUnavailableError
 from fedn.network.state import ReducerState, ReducerStateToString
@@ -230,7 +230,7 @@ class API:
         file_name = file.filename
         storage_file_name = secure_filename(f"{str(uuid.uuid4())}.{extension}")
 
-        file_path = safe_join(os.getcwd(), storage_file_name)
+        file_path = safe_join(FEDN_COMPUTE_PACKAGE_DIR, storage_file_name)
         file.save(file_path)
 
         self.control.set_compute_package(storage_file_name, file_path)
@@ -370,22 +370,20 @@ class API:
         try:
             mutex = threading.Lock()
             mutex.acquire()
-            # TODO: make configurable, perhaps in config.py or package.py
-            return send_from_directory(os.getcwd(), name, as_attachment=True)
+
+            return send_from_directory(FEDN_COMPUTE_PACKAGE_DIR, name, as_attachment=True)
         except Exception:
             try:
                 data = self.control.get_compute_package(name)
                 # TODO: make configurable, perhaps in config.py or package.py
-                file_path = safe_join(os.getcwd(), name)
+                file_path = safe_join(FEDN_COMPUTE_PACKAGE_DIR, name)
                 with open(file_path, "wb") as fh:
                     fh.write(data)
                 # TODO: make configurable, perhaps in config.py or package.py
-                return send_from_directory(os.getcwd(), name, as_attachment=True)
+                return send_from_directory(FEDN_COMPUTE_PACKAGE_DIR, name, as_attachment=True)
             except Exception:
                 raise
         finally:
-            # Delete the file after it has been saved
-            os.remove(file_path)
             mutex.release()
 
     def _create_checksum(self, name=None):

--- a/fedn/network/api/v1/model_routes.py
+++ b/fedn/network/api/v1/model_routes.py
@@ -5,19 +5,13 @@ from flask import Blueprint, jsonify, request, send_file
 
 from fedn.network.api.auth import jwt_auth_required
 from fedn.network.api.shared import modelstorage_config
-from fedn.network.api.v1.shared import api_version, get_limit, get_post_data_to_kwargs, get_reverse, get_typed_list_headers, mdb
-from fedn.network.storage.s3.base import RepositoryBase
-from fedn.network.storage.s3.miniorepository import MINIORepository
+from fedn.network.api.v1.shared import api_version, get_limit, get_post_data_to_kwargs, get_reverse, get_typed_list_headers, mdb, minio_repository
 from fedn.network.storage.statestore.stores.model_store import ModelStore
 from fedn.network.storage.statestore.stores.shared import EntityNotFound
 
 bp = Blueprint("model", __name__, url_prefix=f"/api/{api_version}/models")
 
 model_store = ModelStore(mdb, "control.model")
-repository: RepositoryBase = None
-
-if modelstorage_config["storage_type"] == "S3":
-    repository = MINIORepository(modelstorage_config["storage_config"])
 
 
 @bp.route("/", methods=["GET"])
@@ -631,11 +625,11 @@ def download(id: str):
                         type: string
     """
     try:
-        if repository is not None:
+        if minio_repository is not None:
             model = model_store.get(id, use_typing=False)
             model_id = model["model"]
 
-            file = repository.get_artifact_stream(model_id, modelstorage_config["storage_config"]["storage_bucket"])
+            file = minio_repository.get_artifact_stream(model_id, modelstorage_config["storage_config"]["storage_bucket"])
 
             return send_file(file, as_attachment=True, download_name=model_id)
         else:
@@ -685,11 +679,11 @@ def get_parameters(id: str):
                         type: string
     """
     try:
-        if repository is not None:
+        if minio_repository is not None:
             model = model_store.get(id, use_typing=False)
             model_id = model["model"]
 
-            file = repository.get_artifact_stream(model_id, modelstorage_config["storage_config"]["storage_bucket"])
+            file = minio_repository.get_artifact_stream(model_id, modelstorage_config["storage_config"]["storage_bucket"])
 
             file_bytes = io.BytesIO()
             for chunk in file.stream(32 * 1024):

--- a/fedn/network/api/v1/package_routes.py
+++ b/fedn/network/api/v1/package_routes.py
@@ -426,7 +426,7 @@ def get_active_package():
 
         return jsonify(response), 200
     except EntityNotFound:
-        return jsonify({"message": f"Entity with id: {id} not found"}), 404
+        return jsonify({"message": "Entity not found"}), 404
     except Exception:
         return jsonify({"message": "An unexpected error occurred"}), 500
 
@@ -460,6 +460,39 @@ def set_active_package():
         package_id = data["id"]
         package_store.set_active(package_id)
         return jsonify({"message": "Active package set"}), 200
+    except Exception:
+        return jsonify({"message": "An unexpected error occurred"}), 500
+
+
+@bp.route("/active", methods=["DELETE"])
+@jwt_auth_required(role="admin")
+def delete_active_package():
+    """Set active package
+    Sets the active package
+    ---
+    tags:
+        - Packages
+    responses:
+        200:
+            description: The package was set as active
+            schema:
+                type: object
+                properties:
+                    message:
+                        type: string
+        500:
+            description: An error occurred
+            schema:
+                type: object
+                properties:
+                    message:
+                        type: string
+    """
+    try:
+        package_store.delete_active()
+        return jsonify({"message": "Active package deleted"}), 200
+    except EntityNotFound:
+        return jsonify({"message": "Entity not found"}), 404
     except Exception:
         return jsonify({"message": "An unexpected error occurred"}), 500
 

--- a/fedn/network/api/v1/package_routes.py
+++ b/fedn/network/api/v1/package_routes.py
@@ -467,14 +467,21 @@ def set_active_package():
 @bp.route("/active", methods=["DELETE"])
 @jwt_auth_required(role="admin")
 def delete_active_package():
-    """Set active package
-    Sets the active package
+    """Delete active package
+    Deletes the active package
     ---
     tags:
         - Packages
     responses:
         200:
-            description: The package was set as active
+            description: The active package was deleted
+            schema:
+                type: object
+                properties:
+                    message:
+                        type: string
+        404:
+            description: There was no active package present
             schema:
                 type: object
                 properties:

--- a/fedn/network/api/v1/package_routes.py
+++ b/fedn/network/api/v1/package_routes.py
@@ -1,7 +1,10 @@
+import os
+
 from flask import Blueprint, jsonify, request
+from werkzeug.security import safe_join
 
 from fedn.network.api.auth import jwt_auth_required
-from fedn.network.api.v1.shared import api_version, get_post_data_to_kwargs, get_typed_list_headers, get_use_typing, mdb
+from fedn.network.api.v1.shared import api_version, get_post_data_to_kwargs, get_typed_list_headers, get_use_typing, mdb, repository
 from fedn.network.storage.statestore.stores.package_store import PackageStore
 from fedn.network.storage.statestore.stores.shared import EntityNotFound
 
@@ -425,3 +428,108 @@ def get_active_package():
         return jsonify({"message": f"Entity with id: {id} not found"}), 404
     except Exception:
         return jsonify({"message": "An unexpected error occurred"}), 500
+
+@bp.route("/active", methods=["PUT"])
+@jwt_auth_required(role="admin")
+def set_active_package():
+    """Set active package
+    Sets the active package
+    ---
+    tags:
+        - Packages
+    responses:
+        200:
+            description: The package was set as active
+            schema:
+                type: object
+                properties:
+                    message:
+                        type: string
+        500:
+            description: An error occurred
+            schema:
+                type: object
+                properties:
+                    message:
+                        type: string
+    """
+    try:
+        data = request.json
+        package_id = data["id"]
+        package_store.set_active(package_id)
+        return jsonify({"message": "Active package set"}), 200
+    except Exception:
+        return jsonify({"message": "An unexpected error occurred"}), 500
+
+@bp.route("/", methods=["POST"])
+@jwt_auth_required(role="admin")
+def upload_package():
+  """Upload a package
+  Uploads a package to the system. The package is stored in the database and the file is stored in the file system.
+  ---
+  tags:
+    - Packages
+  requestBody:
+    required: true
+    content:
+      multipart/form-data:
+        schema:
+          type: object
+          properties:
+            name:
+              type: string
+              description: The name of the package
+            description:
+              type: string
+              description: The description of the package
+            file:
+              type: string
+              format: binary
+              description: The package file
+            helper:
+              type: string
+              description: The helper setting for the package
+            file_name:
+              type: string
+              description: The display name of the file
+  responses:
+    200:
+      description: The package was uploaded
+      schema:
+        type: object
+        properties:
+          message:
+            type: string
+    500:
+      description: An error occurred
+      schema:
+        type: object
+        properties:
+          message:
+            type: string
+  """
+  try:
+    data = request.form.to_dict()
+    file = request.files["file"]
+    file_name = file.filename
+
+    data["file_name"] = file_name
+
+    valid, response = package_store.add(data)
+
+    if not valid:
+      return jsonify({"message": response}), 400
+
+    storage_file_name = response["storage_file_name"]
+    try:
+      file_path = safe_join(os.getcwd(), storage_file_name)
+      file.save(file_path)
+      repository.set_compute_package(storage_file_name, file_path)
+    except Exception:
+      package_store.delete(response["id"])
+      return jsonify({"message": "An unexpected error occurred"}), 500
+
+    package_store.set_active(response["id"])
+    return jsonify({"message": "Package uploaded"}), 200
+  except Exception:
+    return jsonify({"message": "An unexpected error occurred"}), 500

--- a/fedn/network/storage/statestore/stores/model_store.py
+++ b/fedn/network/storage/statestore/stores/model_store.py
@@ -63,7 +63,7 @@ class ModelStore(Store[Model]):
 
         return True, ""
 
-    def _complement(self, item: Model) -> Model:
+    def _complement(self, item: Model):
         if "key" not in item or item["key"] is None:
             item["key"] = "models"
 

--- a/fedn/network/storage/statestore/stores/package_store.py
+++ b/fedn/network/storage/statestore/stores/package_store.py
@@ -1,8 +1,11 @@
+import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Tuple
 
 import pymongo
+from bson import ObjectId
 from pymongo.database import Database
+from werkzeug.utils import secure_filename
 
 from fedn.network.storage.statestore.stores.store import Store
 
@@ -78,27 +81,129 @@ class PackageStore(Store[Package]):
 
         return Package.from_dict(document, response_active)
 
+    def _validate(self, item: Package) -> Tuple[bool, str]:
+        if "file_name" not in item or not item["file_name"]:
+            return False, "File name is required"
+
+        if not self._allowed_file_extension(item["file_name"]):
+            return False, "File extension not allowed"
+
+        if "helper" not in item or not item["helper"]:
+            return False, "Helper is required"
+
+        return True, ""
+
+    def _complement(self, item: Package):
+        if "id" not in item or item.id is None:
+            item["id"] = str(uuid.uuid4())
+
+        if "key" not in item or item.key is None:
+            item["key"] = "package_trail"
+
+        if "committed_at" not in item or item.committed_at is None:
+            item["committed_at"] = datetime.now()
+
+        extension = item["file_name"].rsplit(".", 1)[1].lower()
+
+        if "storage_file_name" not in item or item.storage_file_name is None:
+            storage_file_name = secure_filename(f"{str(uuid.uuid4())}.{extension}")
+            item["storage_file_name"] = storage_file_name
+
+    def set_active(self, id: str) -> bool:
+        """Set the active entity
+        param id: The id of the entity
+            type: str
+        return: Whether the operation was successful
+        """
+        kwargs = { "_id": ObjectId(id) } if ObjectId.is_valid(id) else { "id": id }
+        kwargs["key"] = "package_trail"
+
+        document = self.database[self.collection].find_one(kwargs)
+
+        if document is None:
+            raise EntityNotFound(f"Entity with id {id} not found")
+
+        committed_at = datetime.now()
+        obj_to_insert = {
+            "key": "active",
+            "id": document["id"],
+            "committed_at": committed_at,
+            "description": document["description"],
+            "file_name": document["file_name"],
+            "helper": document["helper"],
+            "name": document["name"],
+            "storage_file_name": document["storage_file_name"]
+        }
+
+        self.database[self.collection].update_one({"key": "active"}, {"$set": obj_to_insert}, upsert=True)
+
+        return True
+
     def get_active(self, use_typing: bool = False) -> Package:
         """Get the active entity
         param use_typing: Whether to return the entity as a typed object or as a dict
             type: bool
         return: The entity
         """
-        response = self.database[self.collection].find_one({"key": "active"})
+        kwargs = { "_id": ObjectId(id) } if ObjectId.is_valid(id) else { "id": id }
+        kwargs["key"] = "active"
+        response = self.database[self.collection].find_one(kwargs)
 
         if response is None:
             raise EntityNotFound(f"Entity with id {id} not found")
 
         return Package.from_dict(response, response) if use_typing else from_document(response)
 
+    def _allowed_file_extension(self, filename: str, ALLOWED_EXTENSIONS={"gz", "bz2", "tar", "zip", "tgz"}) -> bool:
+        """Check if file extension is allowed.
+
+        :param filename: The filename to check.
+        :type filename: str
+        :return: True and extension str if file extension is allowed, else False and None.
+        :rtype: Tuple (bool, str)
+        """
+        if "." in filename:
+            extension = filename.rsplit(".", 1)[1].lower()
+            if extension in ALLOWED_EXTENSIONS:
+                return True
+
+        return False
+
+
+
     def update(self, id: str, item: Package) -> bool:
         raise NotImplementedError("Update not implemented for PackageStore")
 
     def add(self, item: Package)-> Tuple[bool, Any]:
-        raise NotImplementedError("Add not implemented for PackageStore")
+        valid, message = self._validate(item)
+        if not valid:
+            return False, message
+
+        self._complement(item)
+
+        return super().add(item)
 
     def delete(self, id: str) -> bool:
-        raise NotImplementedError("Delete not implemented for PackageStore")
+        kwargs = { "_id": ObjectId(id) } if ObjectId.is_valid(id) else { "id": id }
+        kwargs["key"] = "package_trail"
+        document = self.database[self.collection].find_one(kwargs)
+
+        if document is None:
+            raise EntityNotFound(f"Entity with (id) {id} not found")
+
+        result = super().delete(document["_id"])
+
+        if not result:
+            return False
+
+        kwargs["key"] = "active"
+
+        document_active = self.database[self.collection].find_one(kwargs)
+
+        if document_active is not None:
+            return super().delete(document_active["_id"])
+
+        return True
 
     def list(self, limit: int, skip: int, sort_key: str, sort_order=pymongo.DESCENDING, use_typing: bool = False, **kwargs) -> Dict[int, List[Package]]:
         """List entities


### PR DESCRIPTION
## New endpoints

- **POST** /packages | Uploads a compute package. Stores file in minio and object in mongo. Sets the uploaded package as active.
- **PUT** /packages/active | Expects an "id" property in the body. Sets the provided package (id) as active..
- **DELETE** /packages/active | Deletes the current "active" object (compute package). Thus making no package active. The remove package is still present in the db though, just not in active stage.

### New env

- **FEDN_COMPUTE_PACKAGE_DIR** - config where the compute package is to be stored on disk on the server. 