### PR TITLE
Feature/SK-948 | Combiner config flags in fedn client 

### DIFF
--- a/fedn/cli/client_cmd.py
+++ b/fedn/cli/client_cmd.py
@@ -16,9 +16,12 @@ def validate_client_config(config):
     """
     try:
         if config["discover_host"] is None or config["discover_host"] == "":
-            raise InvalidClientConfig("Missing required configuration: discover_host")
+            if config["combiner"] is None or config["combiner"] == "":
+                raise InvalidClientConfig("Missing required configuration: discover_host or combiner")
         if "discover_port" not in config.keys():
             config["discover_port"] = None
+        if config["remote_compute_context"] and config["discover_host"] is None:
+            raise InvalidClientConfig("Remote compute context requires discover_host")
     except Exception:
         raise InvalidClientConfig("Could not load config from file. Check config")
 

--- a/fedn/network/clients/client.py
+++ b/fedn/network/clients/client.py
@@ -88,6 +88,17 @@ class Client:
             if config["proxy_server"]:
                 combiner_config["fqdn"] = config["proxy_server"]
         else:
+            self.connector = ConnectorClient(
+                host=config["discover_host"],
+                port=config["discover_port"],
+                token=config["token"],
+                name=config["name"],
+                remote_package=config["remote_compute_context"],
+                force_ssl=config["force_ssl"],
+                verify=config["verify"],
+                combiner=config["preferred_combiner"],
+                id=self.id,
+            )
             combiner_config = self.assign()
         self.connect(combiner_config)
 

--- a/fedn/network/clients/client.py
+++ b/fedn/network/clients/client.py
@@ -62,18 +62,6 @@ class Client:
 
         self.id = config["client_id"] or str(uuid.uuid4())
 
-        self.connector = ConnectorClient(
-            host=config["discover_host"],
-            port=config["discover_port"],
-            token=config["token"],
-            name=config["name"],
-            remote_package=config["remote_compute_context"],
-            force_ssl=config["force_ssl"],
-            verify=config["verify"],
-            combiner=config["preferred_combiner"],
-            id=self.id,
-        )
-
         # Validate client name
         match = re.search(VALID_NAME_REGEX, config["name"])
         if not match:
@@ -94,8 +82,13 @@ class Client:
 
         self.inbox = queue.Queue()
 
-        # Attach to the FEDn network (get combiner)
-        combiner_config = self.assign()
+        # Attach to the FEDn network (get combiner or attach directly)
+        if config["combiner"]:
+            combiner_config = {"status": "assigned", "host": config["combiner"], "port": config["combiner_port"], "helper_type": ""}
+            if config["proxy_server"]:
+                combiner_config["fqdn"] = config["proxy_server"]
+        else:
+            combiner_config = self.assign()
         self.connect(combiner_config)
 
         self._initialize_dispatcher(self.config)


### PR DESCRIPTION
Using --combiner and --proxy-server the fedn client can now directly connect to the combiner (grpc server) without going via discover service at controller. --combiner is the hostname, proxy_server is e.g grpc.fedn.scaleoutsystems.com