### PR TITLE
Bugfix/SK-1063 | Update sys_platform for windows in environment markers

### DIFF
--- a/examples/FedSimSiam/client/python_env.yaml
+++ b/examples/FedSimSiam/client/python_env.yaml
@@ -4,12 +4,12 @@ build_dependencies:
   - setuptools
   - wheel==0.37.1
 dependencies:
-  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   # PyTorch macOS x86 builds deprecation
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"
   - fedn

--- a/examples/flower-client/client/python_env.yaml
+++ b/examples/flower-client/client/python_env.yaml
@@ -5,12 +5,12 @@ build_dependencies:
   - wheel==0.37.1
 dependencies:
   - fedn[flower]
-  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   # PyTorch macOS x86 builds deprecation
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"
   - fire==0.3.1

--- a/examples/huggingface/client/python_env.yaml
+++ b/examples/huggingface/client/python_env.yaml
@@ -4,12 +4,12 @@ build_dependencies:
   - setuptools
   - wheel
 dependencies:
-  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   # PyTorch macOS x86 builds deprecation
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"
   - transformers

--- a/examples/mnist-pytorch-DPSGD/client/python_env.yaml
+++ b/examples/mnist-pytorch-DPSGD/client/python_env.yaml
@@ -5,12 +5,12 @@ build_dependencies:
   - wheel
 dependencies:
   - fedn
-  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   # PyTorch macOS x86 builds deprecation
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"
   - opacus

--- a/examples/mnist-pytorch/client/python_env.yaml
+++ b/examples/mnist-pytorch/client/python_env.yaml
@@ -5,11 +5,11 @@ build_dependencies:
   - wheel
 dependencies:
   - fedn
-  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   # PyTorch macOS x86 builds deprecation
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"

--- a/examples/monai-2D-mednist/client/python_env.yaml
+++ b/examples/monai-2D-mednist/client/python_env.yaml
@@ -5,12 +5,12 @@ build_dependencies:
   - wheel
 dependencies:
   - fedn
-  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   # PyTorch macOS x86 builds deprecation
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
+  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"
   - monai-weekly[pillow, tqdm]


### PR DESCRIPTION
Wrong sys_platform for windows was used in examples python_env.yaml. "win" does not match both "win32" and "win64". Need to add checks for both.