### PR TITLE
Fix/SK-1060 | Move mnist data to scaleout public bucket

### DIFF
--- a/examples/mnist-pytorch/client/data.py
+++ b/examples/mnist-pytorch/client/data.py
@@ -1,5 +1,4 @@
 import os
-from math import floor
 
 import numpy as np
 import requests

--- a/examples/mnist-pytorch/client/data.py
+++ b/examples/mnist-pytorch/client/data.py
@@ -14,7 +14,7 @@ def get_data(out_dir="data"):
 
     if not os.path.exists(f"{abs_path}/{out_dir}/clients/{split_id}"):
         # create directory for data
-        os.makedirs(f"{abs_path}/{out_dir}data/clients/{split_id}")
+        os.makedirs(f"{abs_path}/{out_dir}/clients/{split_id}")
 
     # use requests to download the data from url
     url = f"https://storage.googleapis.com/public-scaleout/mnist-pytorch/data/clients/{split_id}/mnist.pt"

--- a/examples/mnist-pytorch/client/data.py
+++ b/examples/mnist-pytorch/client/data.py
@@ -12,12 +12,9 @@ def get_data(out_dir="data"):
     # Generate random int between 1 and 10 for split id, set seed for reproducibility
     split_id = np.random.randint(1, 11)
 
-    # set split id as environment variable
-    os.environ["FEDN_DATA_SPLIT_ID"] = str(split_id)
-
-    if not os.path.exists(out_dir + f"/clients/{split_id}"):
+    if not os.path.exists(f"{out_dir}/clients/{split_id}"):
         # create directory for data
-        os.makedirs(out_dir + f"/clients/{split_id}")
+        os.makedirs(f"{out_dir}data/clients/{split_id}")
 
     # use requests to download the data from url
     url = f"https://storage.googleapis.com/public-scaleout/mnist-pytorch/data/clients/{split_id}/mnist.pt"

--- a/examples/mnist-pytorch/client/data.py
+++ b/examples/mnist-pytorch/client/data.py
@@ -12,16 +12,16 @@ def get_data(out_dir="data"):
     # Generate random int between 1 and 10 for split id, set seed for reproducibility
     split_id = np.random.randint(1, 11)
 
-    if not os.path.exists(f"{out_dir}/clients/{split_id}"):
+    if not os.path.exists(f"{abs_path}/{out_dir}/clients/{split_id}"):
         # create directory for data
-        os.makedirs(f"{out_dir}data/clients/{split_id}")
+        os.makedirs(f"{abs_path}/{out_dir}data/clients/{split_id}")
 
     # use requests to download the data from url
     url = f"https://storage.googleapis.com/public-scaleout/mnist-pytorch/data/clients/{split_id}/mnist.pt"
     # download into out_dir
     r = requests.get(url)
     if r.status_code == 200:
-        with open(f"{out_dir}/clients/{split_id}/mnist.pt", "wb") as f:
+        with open(f"{abs_path}/{out_dir}/clients/{split_id}/mnist.pt", "wb") as f:
             f.write(r.content)
         print(f"Downloaded data from {url}")
     else:

--- a/examples/mnist-pytorch/client/data.py
+++ b/examples/mnist-pytorch/client/data.py
@@ -1,23 +1,35 @@
 import os
 from math import floor
 
+import numpy as np
+import requests
 import torch
-import torchvision
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
 abs_path = os.path.abspath(dir_path)
 
 
 def get_data(out_dir="data"):
-    # Make dir if necessary
-    if not os.path.exists(out_dir):
-        os.mkdir(out_dir)
+    # Generate random int between 1 and 10 for split id, set seed for reproducibility
+    split_id = np.random.randint(1, 11)
 
-    # Only download if not already downloaded
-    if not os.path.exists(f"{out_dir}/train"):
-        torchvision.datasets.MNIST(root=f"{out_dir}/train", transform=torchvision.transforms.ToTensor, train=True, download=True)
-    if not os.path.exists(f"{out_dir}/test"):
-        torchvision.datasets.MNIST(root=f"{out_dir}/test", transform=torchvision.transforms.ToTensor, train=False, download=True)
+    # set split id as environment variable
+    os.environ["FEDN_DATA_SPLIT_ID"] = str(split_id)
+
+    if not os.path.exists(out_dir + f"/clients/{split_id}"):
+        # create directory for data
+        os.makedirs(out_dir + f"/clients/{split_id}")
+
+    # use requests to download the data from url
+    url = f"https://storage.googleapis.com/public-scaleout/mnist-pytorch/data/clients/{split_id}/mnist.pt"
+    # download into out_dir
+    r = requests.get(url)
+    if r.status_code == 200:
+        with open(f"{out_dir}/clients/{split_id}/mnist.pt", "wb") as f:
+            f.write(r.content)
+        print(f"Downloaded data from {url}")
+    else:
+        print(f"Failed to download data from {url}")
 
 
 def load_data(data_path, is_train=True):
@@ -31,7 +43,19 @@ def load_data(data_path, is_train=True):
     :rtype: tuple
     """
     if data_path is None:
-        data_path = os.environ.get("FEDN_DATA_PATH", abs_path + "/data/clients/1/mnist.pt")
+        split_id = 0
+        for id in range(1, 11):
+            if os.path.exists(f"{abs_path}/data/clients/{id}/mnist.pt"):
+                split_id = id
+                print(f"Found data at {abs_path}/data/clients/{id}/mnist.pt")
+                break
+        print(f"Using split id {split_id}")
+        data_path = f"{abs_path}/data/clients/{split_id}/mnist.pt"
+        data_path = os.environ.get("FEDN_DATA_PATH", data_path)
+        # check if data_path is a file
+        if not os.path.isfile(data_path):
+            print(f"Data file {data_path} not found.")
+            raise FileNotFoundError
 
     data = torch.load(data_path)
 
@@ -48,50 +72,6 @@ def load_data(data_path, is_train=True):
     return X, y
 
 
-def splitset(dataset, parts):
-    n = dataset.shape[0]
-    local_n = floor(n / parts)
-    result = []
-    for i in range(parts):
-        result.append(dataset[i * local_n : (i + 1) * local_n])
-    return result
-
-
-def split(out_dir="data"):
-    n_splits = int(os.environ.get("FEDN_NUM_DATA_SPLITS", 2))
-
-    # Make dir
-    if not os.path.exists(f"{out_dir}/clients"):
-        os.mkdir(f"{out_dir}/clients")
-
-    # Load and convert to dict
-    train_data = torchvision.datasets.MNIST(root=f"{out_dir}/train", transform=torchvision.transforms.ToTensor, train=True)
-    test_data = torchvision.datasets.MNIST(root=f"{out_dir}/test", transform=torchvision.transforms.ToTensor, train=False)
-    data = {
-        "x_train": splitset(train_data.data, n_splits),
-        "y_train": splitset(train_data.targets, n_splits),
-        "x_test": splitset(test_data.data, n_splits),
-        "y_test": splitset(test_data.targets, n_splits),
-    }
-
-    # Make splits
-    for i in range(n_splits):
-        subdir = f"{out_dir}/clients/{str(i+1)}"
-        if not os.path.exists(subdir):
-            os.mkdir(subdir)
-        torch.save(
-            {
-                "x_train": data["x_train"][i],
-                "y_train": data["y_train"][i],
-                "x_test": data["x_test"][i],
-                "y_test": data["y_test"][i],
-            },
-            f"{subdir}/mnist.pt",
-        )
-
-
 if __name__ == "__main__":
     # Prepare data if not already done
-    if not os.path.exists(abs_path + "/data/clients/1"):
-        get_data()
-        split()
+    get_data()

--- a/examples/mnist-pytorch/client/python_env.yaml
+++ b/examples/mnist-pytorch/client/python_env.yaml
@@ -8,8 +8,6 @@ dependencies:
   - torch==2.4.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   # PyTorch macOS x86 builds deprecation
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
-  - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"


### PR DESCRIPTION
This pull request includes significant changes to the data handling and dependencies in the `examples/mnist-pytorch/client` project. The most important changes involve replacing the use of `torchvision` with direct data downloads, updating the data loading logic, and modifying the environment dependencies.

### Data Handling Improvements:

* [`examples/mnist-pytorch/client/data.py`](diffhunk://#diff-8c45613695cb7a03b1da1922cc8394aa271841a45fdc0922fc1d601ab5784712R4-R32): Replaced `torchvision` dataset download with direct data download using `requests`. This includes setting a random split ID and downloading the corresponding data file from Scaleout's own public bucket.
* [`examples/mnist-pytorch/client/data.py`](diffhunk://#diff-8c45613695cb7a03b1da1922cc8394aa271841a45fdc0922fc1d601ab5784712L34-R58): Updated the `load_data` function to dynamically find the correct data split ID and verify the existence of the data file.
* [`examples/mnist-pytorch/client/data.py`](diffhunk://#diff-8c45613695cb7a03b1da1922cc8394aa271841a45fdc0922fc1d601ab5784712L51-L97): Removed the `splitset` and `split` functions, as the data splitting is now handled by the pre-downloaded data files.

### Dependency Updates:

* [`examples/mnist-pytorch/client/python_env.yaml`](diffhunk://#diff-1e30a56a7e6d471ce83c548eddd8c01c9b6d29c37088701b92d3b0f65111463aL11-L12): Removed `torchvision` from the dependencies and updated `numpy` versions to ensure compatibility with different platforms and Python versions.