### PR TITLE
Bugfix/SK-1040 | Bug in example monai-2D-mednist

### DIFF
--- a/examples/monai-2D-mednist/client/python_env.yaml
+++ b/examples/monai-2D-mednist/client/python_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==2.0.2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy<2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"
   - monai-weekly[pillow, tqdm]

--- a/examples/monai-2D-mednist/client/python_env.yaml
+++ b/examples/monai-2D-mednist/client/python_env.yaml
@@ -10,7 +10,7 @@ dependencies:
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy<2; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
   - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
   - numpy==1.24.4; python_version == "3.8"
   - monai-weekly[pillow, tqdm]

--- a/examples/monai-2D-mednist/client/python_env.yaml
+++ b/examples/monai-2D-mednist/client/python_env.yaml
@@ -10,8 +10,7 @@ dependencies:
   - torch==2.2.2; sys_platform == "darwin" and platform_machine == "x86_64"
   - torchvision==0.19.1; (sys_platform == "darwin" and platform_machine == "arm64") or (sys_platform == "win32" or sys_platform == "win64" or sys_platform == "linux")
   - torchvision==0.17.2; sys_platform == "darwin" and platform_machine == "x86_64"
-  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
-  - numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+  - numpy==1.26.4; python_version >= "3.9"
   - numpy==1.24.4; python_version == "3.8"
   - monai-weekly[pillow, tqdm]
   - scikit-learn  

--- a/examples/monai-2D-mednist/client/train.py
+++ b/examples/monai-2D-mednist/client/train.py
@@ -72,7 +72,6 @@ def train(in_model_path, out_model_path, data_path=None, client_settings_path=No
         clients = yaml.safe_load(file)
 
     image_list = clients["client " + str(split_index)]["train"]
-
     train_ds = MedNISTDataset(data_path=data_path+"/MedNIST/", transforms=train_transforms, image_files=image_list)
     train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True, num_workers=num_workers)
 
@@ -101,7 +100,7 @@ def train(in_model_path, out_model_path, data_path=None, client_settings_path=No
             loss.backward()
             optimizer.step()
             epoch_loss += loss.item()
-            print(f"{step}/{len(train_loader) // train_loader.batch_size}, " f"train_loss: {loss.item():.4f}")
+            print(f"{step}/{len(train_loader)}, " f"train_loss: {loss.item():.4f}")
 
         epoch_loss /= step
         epoch_loss_values.append(epoch_loss)

--- a/examples/monai-2D-mednist/requirements.txt
+++ b/examples/monai-2D-mednist/requirements.txt
@@ -1,5 +1,4 @@
 monai
 PyYAML
-numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
-numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+numpy==1.26.4; python_version >= "3.9"
 numpy==1.24.4; python_version == "3.8"

--- a/examples/monai-2D-mednist/requirements.txt
+++ b/examples/monai-2D-mednist/requirements.txt
@@ -1,3 +1,5 @@
 monai
 PyYAML
-numpy==1.26.4
+numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "arm64" and python_version >= "3.9") or (sys_platform == "win" or sys_platform == "linux" and python_version >= "3.9")
+numpy==1.26.4; (sys_platform == "darwin" and platform_machine == "x86_64" and python_version >= "3.9")
+numpy==1.24.4; python_version == "3.8"


### PR DESCRIPTION
## Description
 numpy<2 is required by monAI so this pr pin numpy to 1.24.4 for python 3.8 and 1.26.4 for python >=3.9

<!-- 
 
-->

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->