### PR TITLE
Fix/SK-1076 | FutureWarning torch.load

### DIFF
--- a/examples/FedSimSiam/client/data.py
+++ b/examples/FedSimSiam/client/data.py
@@ -39,7 +39,7 @@ def load_data(data_path, is_train=True):
         data_path = os.environ.get(
             "FEDN_DATA_PATH", abs_path+"/data/clients/1/cifar10.pt")
 
-    data = torch.load(data_path)
+    data = torch.load(data_path, weights_only=True)
 
     if is_train:
         X = data["x_train"]

--- a/examples/huggingface/client/data.py
+++ b/examples/huggingface/client/data.py
@@ -11,7 +11,7 @@ abs_path = os.path.abspath(dir_path)
 def load_data(data_path=None, is_train=True):
     if data_path is None:
         data_path = os.environ.get("FEDN_DATA_PATH", abs_path + "/data/clients/1/enron_spam.pt")
-    data = torch.load(data_path)
+    data = torch.load(data_path, weights_only=True)
     if is_train:
         X = data["X_train"]
         y = data["y_train"]

--- a/examples/mnist-pytorch-DPSGD/client/data.py
+++ b/examples/mnist-pytorch-DPSGD/client/data.py
@@ -35,7 +35,7 @@ def load_data(data_path, is_train=True):
         data_path = os.environ.get("FEDN_DATA_PATH", abs_path + "/data/clients/1/mnist.pt")
 
     print("data path: ", data_path)
-    data = torch.load(data_path)
+    data = torch.load(data_path, weights_only=True)
 
     if is_train:
         X = data["x_train"]

--- a/examples/mnist-pytorch/client/data.py
+++ b/examples/mnist-pytorch/client/data.py
@@ -33,7 +33,7 @@ def load_data(data_path, is_train=True):
     if data_path is None:
         data_path = os.environ.get("FEDN_DATA_PATH", abs_path + "/data/clients/1/mnist.pt")
 
-    data = torch.load(data_path)
+    data = torch.load(data_path, weights_only=True)
 
     if is_train:
         X = data["x_train"]


### PR DESCRIPTION
FutureWarning occurs when torch.load() is called without specifying the 'weights_only' parameter. 
To prevent this, the parameter 'weights_only' is set to 'True'. This is the default behavior and does not change any functionality.

Changed for the following examples:
- mnist-pytorch
- mnist-pytorch with DP
- huggingface
- FedSimSiam