### PR TITLE
Bugfix/SK-1099 | return status code 400 if model load goes wrong and print logger.error

### DIFF
--- a/fedn/network/api/interface.py
+++ b/fedn/network/api/interface.py
@@ -600,18 +600,30 @@ class API:
         :return: A json response with success or failure message.
         :rtype: :class:`flask.Response`
         """
+        logger.info("Adding model")
         try:
             object = BytesIO()
             object.seek(0, 0)
             file.seek(0)
             object.write(file.read())
             helper = self.control.get_helper()
+            logger.info(f"Loading model from file using helper {helper.name}")
             object.seek(0)
             model = helper.load(object)
             self.control.commit(file.filename, model)
         except Exception as e:
+            logger.error("Error occured during model loading")
             logger.debug(e)
-            return jsonify({"success": False, "message": "Failed to add initial model."})
+            status_code = 400
+            return (
+                jsonify(
+                    {
+                        "success": False,
+                        "message": "Failed to add model.",
+                    }
+                ),
+                status_code,
+            )
 
         return jsonify({"success": True, "message": "Initial model added successfully."})
 


### PR DESCRIPTION
This pull request includes changes to improve logging and error handling in the `set_initial_model` method of the `fedn/network/api/interface.py` file. The most important changes include adding informative log messages and modifying the error response format.

Improvements to logging:

* Added an info log message when a model is being added. (`fedn/network/api/interface.py`)
* Added an info log message to indicate which helper is being used to load the model. (`fedn/network/api/interface.py`)
* Added an error log message for when an error occurs during model loading. (`fedn/network/api/interface.py`)

Enhancements to error handling:

* Changed the error response to include a status code and a more detailed JSON message. (`fedn/network/api/interface.py`)