### PR TITLE
Refactor/SK-1144 | Simplify on_train and on_validate

### DIFF
--- a/fedn/network/clients/README.rst
+++ b/fedn/network/clients/README.rst
@@ -75,7 +75,7 @@ Step-by-Step Instructions
         print(f"API Token: {token or "-"}")
         print(f"API Port: {api_port or "-"}")
 
-        client_api = ClientAPI()
+        client_api = ClientAPI(train_callback=on_train, validate_callback=on_validate)
 
         url = get_api_url(api_url, api_port)
 
@@ -102,9 +102,6 @@ Step-by-Step Instructions
 
         if not result:
             return
-
-        client_api.set_train_callback(on_train)
-        client_api.set_validate_callback(on_validate)
 
         client_api.run()
 

--- a/fedn/network/clients/README.rst
+++ b/fedn/network/clients/README.rst
@@ -26,110 +26,97 @@ Step-by-Step Instructions
 
     import argparse
     import json
-    import threading
     import uuid
-    
-    import fedn.network.grpc.fedn_pb2 as fedn
+
     from fedn.network.clients.client_api import ClientAPI, ConnectToApiResult
-    
-    client_api = ClientAPI()
-    
-    
+
+
+    def get_api_url(api_url: str, api_port: int):
+        url = f"{api_url}:{api_port}" if api_port else api_url
+        if not url.endswith("/"):
+            url += "/"
+        return url
+
+    def on_train(in_model):
+        training_metadata = {
+            "num_examples": 1,
+            "batch_size": 1,
+            "epochs": 1,
+            "lr": 1,
+        }
+
+        config = {
+            "round_id": 1,
+        }
+
+        metadata = {
+            "training_metadata": training_metadata,
+            "config": json.dumps(config),
+        }
+
+        # Do your training here, out_model is your result...
+        out_model = in_model
+
+        return out_model, metadata
+
+    def on_validate(in_model):
+
+        # Calculate metrics here...
+        metrics = {
+            "test_accuracy": 0.9,
+            "test_loss": 0.1,
+            "train_accuracy": 0.8,
+            "train_loss": 0.2,
+        }
+        return metrics
+
     def main(api_url: str, api_port: int, token: str = None):
         print(f"API URL: {api_url}")
         print(f"API Token: {token or "-"}")
         print(f"API Port: {api_port or "-"}")
-    
+
+        client_api = ClientAPI()
+
+        url = get_api_url(api_url, api_port)
+
         name = input("Enter Client Name: ")
-    
-        url = f"{api_url}:{api_port}" if api_port else api_url
-    
-        if not url.endswith("/"):
-            url += "/"
-    
-        print(f"Client Name: {name}")
-    
+        client_api.set_name(name)
+
         client_id = str(uuid.uuid4())
-    
-        print("Connecting to API...")
-    
-        client_options = {
-            "name": "client_example",
+        client_api.set_client_id(client_id)
+
+        controller_config = {
+            "name": name,
             "client_id": client_id,
             "package": "local",
             "preferred_combiner": "",
         }
-    
-        result, combiner_config = client_api.connect_to_api(url, token, client_options)
-    
+
+        result, combiner_config = client_api.connect_to_api(url, token, controller_config)
+
         if result != ConnectToApiResult.Assigned:
             print("Failed to connect to API, exiting.")
             return
-    
-        print("Connected to API")
-    
+
         result: bool = client_api.init_grpchandler(config=combiner_config, client_name=client_id, token=token)
-    
+
         if not result:
             return
-    
-        threading.Thread(target=client_api.send_heartbeats, kwargs={"client_name": name, "client_id": client_id}, daemon=True).start()
-    
-        def on_train(request):
-            print("Received train request")
-            model_id: str = request.model_id
-    
-            model = client_api.get_model_from_combiner(id=str(model_id), client_name=name)
-    
-            # Do your training here, out_model is your result...
-            out_model = model
-            updated_model_id = uuid.uuid4()
-            client_api.send_model_to_combiner(out_model, str(updated_model_id))
-    
-            training_metadata = {
-                "num_examples": 1,
-                "batch_size": 1,
-                "epochs": 1,
-                "lr": 1,
-            }
-    
-            config = {
-                "round_id": 1,
-            }
-    
-            client_api.send_model_update(
-                sender_name=name,
-                sender_role=fedn.WORKER,
-                client_id=client_id,
-                model_id=model_id,
-                model_update_id=str(updated_model_id),
-                receiver_name=request.sender.name,
-                receiver_role=request.sender.role,
-                meta={
-                    "training_metadata": training_metadata,
-                    "config": json.dumps(config),
-                },
-            )
-    
-        client_api.subscribe("train", on_train)
-    
-        threading.Thread(target=client_api.listen_to_task_stream, kwargs={"client_name": name, "client_id": client_id}, daemon=True).start()
-    
-        stop_event = threading.Event()
-        try:
-            stop_event.wait()
-        except KeyboardInterrupt:
-            print("Client stopped by user.")
-    
-    
+
+        client_api.set_train_callback(on_train)
+        client_api.set_validate_callback(on_validate)
+
+        client_api.run()
+
     if __name__ == "__main__":
         parser = argparse.ArgumentParser(description="Client Example")
         parser.add_argument("--api-url", type=str, required=True, help="The API URL")
         parser.add_argument("--api-port", type=int, required=False, help="The API Port")
         parser.add_argument("--token", type=str, required=False, help="The API Token")
-    
+
         args = parser.parse_args()
         main(args.api_url, args.api_port, args.token)
+
 
 4. **Run the client**: Run the client by executing the following command:
 

--- a/fedn/network/clients/client_api.py
+++ b/fedn/network/clients/client_api.py
@@ -55,9 +55,9 @@ def get_compute_package_dir_path():
 
 
 class ClientAPI:
-    def __init__(self):
-        self.train_callback: callable = None
-        self.validate_callback: callable = None
+    def __init__(self, train_callback: callable = None, validate_callback: callable = None):
+        self.train_callback: callable = train_callback
+        self.validate_callback: callable = validate_callback
         path = get_compute_package_dir_path()
         self._package_runtime = PackageRuntime(path)
 

--- a/fedn/network/clients/client_api.py
+++ b/fedn/network/clients/client_api.py
@@ -5,7 +5,6 @@ import threading
 from io import BytesIO
 from typing import Any, Tuple
 import uuid
-from abc import ABC, abstractmethod
 import json
 
 import requests
@@ -210,7 +209,7 @@ class ClientAPI:
         if in_model is None:
             logger.error("Could not retrieve model from combiner. Aborting training request.")
             return
-        
+
         fetch_model_time = time.time() - tic
 
         if not self.train_callback:
@@ -293,7 +292,7 @@ class ClientAPI:
                 metrics=metrics,
                 request=request
             )
-        
+
             if result:
                 self.send_status(
                     "Model validation completed.",

--- a/fedn/network/clients/client_v2.py
+++ b/fedn/network/clients/client_v2.py
@@ -1,10 +1,10 @@
 import io
 import json
 import os
-import threading
 import time
 import uuid
 from typing import Tuple
+from io import BytesIO
 
 import fedn.network.grpc.fedn_pb2 as fedn
 from fedn.common.config import FEDN_CUSTOM_URL_PREFIX
@@ -114,22 +114,13 @@ class Client:
 
         logger.info("-----------------------------")
 
-        threading.Thread(
-            target=self.client_api.send_heartbeats, kwargs={"client_name": self.client_obj.name, "client_id": self.client_obj.client_id}, daemon=True
-        ).start()
+        self.client_api.set_train_callback(self.on_train)
+        self.client_api.set_validate_callback(self.on_validation)
 
-        self.client_api.subscribe("train", self.on_train)
-        self.client_api.subscribe("validation", self.on_validation)
+        self.client_api.set_name(self.client_obj.name)
+        self.client_api.set_client_id(self.client_obj.client_id)
 
-        threading.Thread(
-            target=self.client_api.listen_to_task_stream, kwargs={"client_name": self.client_obj.name, "client_id": self.client_obj.client_id}, daemon=True
-        ).start()
-
-        stop_event = threading.Event()
-        try:
-            stop_event.wait()
-        except KeyboardInterrupt:
-            logger.info("Client stopped by user.")
+        self.client_api.run()
 
     def set_helper(self, response: GrpcConnectionOptions = None):
         helper_type = response.get("helper_type", None)
@@ -141,50 +132,31 @@ class Client:
         # Priority: helper_type from constructor > helper_type from response > default helper_type
         self.helper = get_helper(helper_type_to_use)
 
-    def on_train(self, request):
-        logger.info("Received train request")
-        self._process_training_request(request)
+    def on_train(self, in_model):
+        out_model, meta = self._process_training_request(in_model)
+        return out_model, meta
 
-    def on_validation(self, request):
-        logger.info("Received validation request")
-        self._process_validation_request(request)
+    def on_validation(self, in_model):
+        metrics = self._process_validation_request(in_model)
+        return metrics
 
 
-    def _process_training_request(self, request) -> Tuple[str, dict]:
+    def _process_training_request(self, in_model: BytesIO) -> Tuple[BytesIO, dict]:
         """Process a training (model update) request.
 
-        :param model_id: The model id of the model to be updated.
-        :type model_id: str
-        :param session_id: The id of the current session
-        :type session_id: str
-        :return: The model id of the updated model, or None if the update failed. And a dict with metadata.
+        :param in_model: The model to be updated.
+        :type in_model: BytesIO
+        :return: The updated model, or None if the update failed. And a dict with metadata.
         :rtype: tuple
         """
-        model_id: str = request.model_id
-        session_id: str = request.session_id
-
-        self.client_api.send_status(
-            f"\t Starting processing of training request for model_id {model_id}",
-            sesssion_id=session_id,
-            sender_name=self.client_obj.name
-        )
 
         try:
             meta = {}
-            tic = time.time()
-
-            model = self.client_api.get_model_from_combiner(id=str(model_id), client_name=self.client_obj.client_id)
-
-            if model is None:
-                logger.error("Could not retrieve model from combiner. Aborting training request.")
-                return None, None
-
-            meta["fetch_model"] = time.time() - tic
 
             inpath = self.helper.get_tmp_path()
 
             with open(inpath, "wb") as fh:
-                fh.write(model.getbuffer())
+                fh.write(in_model.getbuffer())
 
             outpath = self.helper.get_tmp_path()
 
@@ -194,16 +166,10 @@ class Client:
 
             meta["exec_training"] = time.time() - tic
 
-            tic = time.time()
             out_model = None
 
             with open(outpath, "rb") as fr:
                 out_model = io.BytesIO(fr.read())
-
-            # Stream model update to combiner server
-            updated_model_id = uuid.uuid4()
-            self.client_api.send_model_to_combiner(out_model, str(updated_model_id))
-            meta["upload_model"] = time.time() - tic
 
             # Read the metadata file
             with open(outpath + "-metadata", "r") as fh:
@@ -218,65 +184,28 @@ class Client:
 
         except Exception as e:
             logger.error("Could not process training request due to error: {}".format(e))
-            updated_model_id = None
+            out_model = None
             meta = {"status": "failed", "error": str(e)}
 
-        if meta is not None:
-            processing_time = time.time() - tic
-            meta["processing_time"] = processing_time
-            meta["config"] = request.data
+        return out_model, meta
 
-        if model_id is not None:
-            # Send model update to combiner
-
-            self.client_api.send_model_update(
-                sender_name=self.client_obj.name,
-                sender_role=fedn.WORKER,
-                client_id=self.client_obj.client_id,
-                model_id=model_id,
-                model_update_id=str(updated_model_id),
-                receiver_name=request.sender.name,
-                receiver_role=request.sender.role,
-                meta=meta,
-            )
-
-            self.client_api.send_status(
-                "Model update completed.",
-                log_level=fedn.Status.AUDIT,
-                type=fedn.StatusType.MODEL_UPDATE,
-                request=request,
-                sesssion_id=session_id,
-                sender_name=self.client_obj.name
-            )
-
-    def _process_validation_request(self, request):
+    def _process_validation_request(self, in_model: BytesIO) -> dict:
         """Process a validation request.
 
-        :param model_id: The model id of the model to be validated.
-        :type model_id: str
-        :param session_id: The id of the current session.
-        :type session_id: str
+        :param in_model: The model to be validated.
+        :type in_model: BytesIO
         :return: The validation metrics, or None if validation failed.
         :rtype: dict
         """
-        model_id: str = request.model_id
-        session_id: str = request.session_id
-        cmd = "validate"
-
-        self.client_api.send_status(f"Processing {cmd} request for model_id {model_id}", sesssion_id=session_id, sender_name=self.client_obj.name)
 
         try:
-            model = self.client_api.get_model_from_combiner(id=str(model_id), client_name=self.client_obj.client_id)
-            if model is None:
-                logger.error("Could not retrieve model from combiner. Aborting validation request.")
-                return
             inpath = self.helper.get_tmp_path()
 
             with open(inpath, "wb") as fh:
-                fh.write(model.getbuffer())
+                fh.write(in_model.getbuffer())
 
             outpath = get_tmp_path()
-            self.client_api.dispatcher.run_cmd(f"{cmd} {inpath} {outpath}")
+            self.client_api.dispatcher.run_cmd(f"validate {inpath} {outpath}")
 
             with open(outpath, "r") as fh:
                 metrics = json.loads(fh.read())
@@ -286,45 +215,6 @@ class Client:
 
         except Exception as e:
             logger.warning("Validation failed with exception {}".format(e))
+            metrics = None
 
-        if metrics is not None:
-            # Send validation
-            validation = fedn.ModelValidation()
-            validation.sender.name = self.client_obj.name
-            validation.sender.role = fedn.WORKER
-            validation.receiver.name = request.sender.name
-            validation.receiver.role = request.sender.role
-            validation.model_id = str(request.model_id)
-            validation.data = json.dumps(metrics)
-            validation.timestamp.GetCurrentTime()
-            validation.correlation_id = request.correlation_id
-            validation.session_id = request.session_id
-
-            # sender_name: str, sender_role: fedn.Role, model_id: str, model_update_id: str
-            result: bool = self.client_api.send_model_validation(
-                sender_name=self.client_obj.name,
-                receiver_name=request.sender.name,
-                receiver_role=request.sender.role,
-                model_id=str(request.model_id),
-                metrics=json.dumps(metrics),
-                correlation_id=request.correlation_id,
-                session_id=request.session_id,
-            )
-
-            if result:
-                self.client_api.send_status(
-                    "Model validation completed.",
-                    log_level=fedn.Status.AUDIT,
-                    type=fedn.StatusType.MODEL_VALIDATION,
-                    request=validation,
-                    sesssion_id=request.session_id,
-                    sender_name=self.client_obj.name
-                )
-            else:
-                self.client_api.send_status(
-                    "Client {} failed to complete model validation.".format(self.name),
-                    log_level=fedn.Status.WARNING,
-                    request=request,
-                    sesssion_id=request.session_id,
-                    sender_name=self.client_obj.name
-                )
+        return metrics

--- a/fedn/network/clients/client_v2.py
+++ b/fedn/network/clients/client_v2.py
@@ -3,10 +3,9 @@ import json
 import os
 import time
 import uuid
-from typing import Tuple
 from io import BytesIO
+from typing import Tuple
 
-import fedn.network.grpc.fedn_pb2 as fedn
 from fedn.common.config import FEDN_CUSTOM_URL_PREFIX
 from fedn.common.log_config import logger
 from fedn.network.clients.client_api import ClientAPI, ConnectToApiResult, GrpcConnectionOptions
@@ -44,16 +43,17 @@ class ClientOptions:
 
 
 class Client:
-    def __init__(self,
-            api_url: str,
-            api_port: int,
-            client_obj: ClientOptions,
-            combiner_host: str = None,
-            combiner_port: int = None,
-            token: str = None,
-            package_checksum: str = None,
-            helper_type: str = None
-        ):
+    def __init__(
+        self,
+        api_url: str,
+        api_port: int,
+        client_obj: ClientOptions,
+        combiner_host: str = None,
+        combiner_port: int = None,
+        token: str = None,
+        package_checksum: str = None,
+        helper_type: str = None,
+    ):
         self.api_url = api_url
         self.api_port = api_port
         self.combiner_host = combiner_host
@@ -140,7 +140,6 @@ class Client:
         metrics = self._process_validation_request(in_model)
         return metrics
 
-
     def _process_training_request(self, in_model: BytesIO) -> Tuple[BytesIO, dict]:
         """Process a training (model update) request.
 
@@ -149,7 +148,6 @@ class Client:
         :return: The updated model, or None if the update failed. And a dict with metadata.
         :rtype: tuple
         """
-
         try:
             meta = {}
 
@@ -197,7 +195,6 @@ class Client:
         :return: The validation metrics, or None if validation failed.
         :rtype: dict
         """
-
         try:
             inpath = self.helper.get_tmp_path()
 

--- a/fedn/network/clients/grpc_handler.py
+++ b/fedn/network/clients/grpc_handler.py
@@ -236,8 +236,6 @@ class GrpcHandler:
 
     def send_model_update(self,
         sender_name: str,
-        sender_role: fedn.Role,
-        client_id: str,
         model_id: str,
         model_update_id: str,
         receiver_name: str,
@@ -246,8 +244,8 @@ class GrpcHandler:
     ):
         update = fedn.ModelUpdate()
         update.sender.name = sender_name
-        update.sender.role = sender_role
-        update.sender.client_id = client_id
+        update.sender.role = fedn.WORKER
+        update.sender.client_id = self.metadata[0][1]
         update.receiver.name = receiver_name
         update.receiver.role = receiver_role
         update.model_id = model_id
@@ -264,7 +262,6 @@ class GrpcHandler:
                 "SendModelUpdate",
                 lambda: self.send_model_update(
                     sender_name,
-                    sender_role,
                     model_id,
                     model_update_id,
                     receiver_name,


### PR DESCRIPTION
**Key changes**
* Moved boiler plate code from client to ClientAPI to make it simpler for the user to implement an on_train/on_validate function
* Updated client_v2 accordingly
* These changes **eliminate the client's** (client_v2 or exemple in README) **need to import fedn protos**

grpc_handler.py
* Removed unnecessary params from `send_model_update()`

client_api.py
* Replaced `_subscribers` with `train_callback` and `validate_callback`
  - `train_callback` needs to take in_model as parameter and return out_model and metadata dict
  - `validate_callback` needs to take in_model as parameter and return metrics dict
* `_task_stream_callback` now invokes `update_local_model` or `validate_global_model` depending on task request type
  - `update_local_model` and `validate_global_model` contain boiler plate code that was previously inside the `on_train` and `on_validate` callbacks (getting/sending model from/to combiner, generating uuid, assembling metadata, sending model update/validation)
  - This replaces the functions `train` and `validate`
* `run` method creates a child thread for heart beats and listens to task stream in main thread

client_v2.py
* Adjusted training and validation functions for the updated client_api.py

README.rst
* Updated example client that makes use of the new API