### PR TITLE
Fix/SK-1181 | Prevent default flag values from always overwriting yaml file

### DIFF
--- a/fedn/cli/client_cmd.py
+++ b/fedn/cli/client_cmd.py
@@ -212,7 +212,7 @@ def _complement_client_params(config: dict):
 @click.option("-u", "--api-url", required=False, help="Hostname for fedn api.")
 @click.option("-p", "--api-port", required=False, help="Port for discovery services (reducer).")
 @click.option("--token", required=False, help="Set token provided by reducer if enabled")
-@click.option("-n", "--name", required=False, default="client" + str(uuid.uuid4())[:8])
+@click.option("-n", "--name", required=False)
 @click.option("-i", "--client-id", required=False)
 @click.option("--local-package", is_flag=True, help="Enable local compute package")
 @click.option("-c", "--preferred-combiner", type=str, required=False, default="", help="name of the preferred combiner")
@@ -291,6 +291,8 @@ def client_start_v2_cmd(
         config["name"] = name
         if config["name"]:
             click.echo(f"Input param name: {name} overrides value from file")
+    elif config["name"] is None:
+        config["name"] = "client" + str(uuid.uuid4())[:8]
 
     if client_id and client_id != "":
         config["client_id"] = client_id

--- a/fedn/cli/client_cmd.py
+++ b/fedn/cli/client_cmd.py
@@ -218,8 +218,8 @@ def _complement_client_params(config: dict):
 @click.option("-c", "--preferred-combiner", type=str, required=False, default="", help="name of the preferred combiner")
 @click.option("--combiner", type=str, required=False, default=None, help="Skip combiner assignment from discover service and attach directly to combiner host.")
 @click.option("--combiner-port", type=str, required=False, default=None, help="Combiner port, need to be used with --combiner")
-@click.option("-va", "--validator", required=False, default=True)
-@click.option("-tr", "--trainer", required=False, default=True)
+@click.option("-va", "--validator", required=False, default=None)
+@click.option("-tr", "--trainer", required=False, default=None)
 @click.option("-h", "--helper_type", required=False, default=None)
 @click.option("-in", "--init", required=False, default=None, help="Set to a filename to (re)init client from file state.")
 @click.pass_context
@@ -318,11 +318,15 @@ def client_start_v2_cmd(
         config["validator"] = validator
         if config["validator"] is not None:
             click.echo(f"Input param validator: {validator} overrides value from file")
+    elif config["validator"] is None:
+        config["validator"] = True
 
     if trainer is not None:
         config["trainer"] = trainer
         if config["trainer"] is not None:
             click.echo(f"Input param trainer: {trainer} overrides value from file")
+    elif config["trainer"] is None:
+        config["trainer"] = True
 
     if helper_type and helper_type != "":
         config["helper_type"] = helper_type


### PR DESCRIPTION
- Previously default values for name, trainer and validator were set using click - which meant they always overwrote the values in yaml file.
- Logic for setting default values is now moved to function body.
- Now, the logic works as presented in the table below. The entries show which value is used in each of the 4 situations.

| Flag\File    | Set | Not set |
| -------- | ------- | ------- |
| Set  | Flag value    | Flag value    |
| Not set | File value    | Default value   |