### PR TITLE
Refactor/SK-1225 | Use api/v1 in APIClient start_session

### DIFF
--- a/examples/monai-2D-mednist/client/validate.py
+++ b/examples/monai-2D-mednist/client/validate.py
@@ -86,8 +86,9 @@ def validate(in_model_path, out_json_path, data_path=None, client_settings_path=
 
     # JSON schema
     report.update({"test_accuracy": accuracy_score(y_true, y_pred), "test_f1_score": f1_score(y_true, y_pred, average="macro")})
-    for r in report:
-        print(r, ": ", report[r])
+
+    for key, value in report.items():
+        print(f"{key}: {value}")
 
     # Save JSON
     save_metrics(report, out_json_path)

--- a/examples/monai-2D-mednist/client/validate.py
+++ b/examples/monai-2D-mednist/client/validate.py
@@ -55,7 +55,7 @@ def validate(in_model_path, out_json_path, data_path=None, client_settings_path=
 
     image_list = clients["client " + str(split_index)]["validation"]
 
-    val_ds = MedNISTDataset(data_path=data_path+"/MedNIST/", transforms=val_transforms, image_files=image_list)
+    val_ds = MedNISTDataset(data_path=data_path + "/MedNIST/", transforms=val_transforms, image_files=image_list)
 
     val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=True, num_workers=num_workers)
 

--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -645,6 +645,9 @@ class APIClient:
             headers=self.headers,
         )
 
+        if id is None:
+            id = response.json()["session_id"]
+
         if response.status_code == 201:
             response = requests.post(
                 self._get_url_api_v1("sessions/start"),

--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -607,25 +607,38 @@ class APIClient:
         :rtype: dict
         """
         response = requests.post(
-            self._get_url("start_session"),
+            self._get_url_api_v1("sessions"),
             json={
                 "session_id": id,
-                "aggregator": aggregator,
-                "aggregator_kwargs": aggregator_kwargs,
-                "model_id": model_id,
-                "round_timeout": round_timeout,
-                "rounds": rounds,
-                "round_buffer_size": round_buffer_size,
-                "delete_models": delete_models,
-                "validate": validate,
-                "helper": helper,
-                "min_clients": min_clients,
-                "requested_clients": requested_clients,
-                "server_functions": None if server_functions is None else inspect.getsource(server_functions),
+                "session_config": {
+                    "aggregator": aggregator,
+                    "aggregator_kwargs": aggregator_kwargs,
+                    "round_timeout": round_timeout,
+                    "buffer_size": round_buffer_size,
+                    "model_id": model_id,
+                    "delete_models_storage": delete_models,
+                    "clients_required": min_clients,
+                    "requested_clients": requested_clients,
+                    "validate": validate,
+                    "helper_type": helper,
+                    "server_functions": None if server_functions is None else inspect.getsource(server_functions),
+                },
             },
             verify=self.verify,
             headers=self.headers,
         )
+
+        if response.status_code == 201:
+            response = requests.post(
+                self._get_url_api_v1("sessions/start"),
+                json={
+                    "session_id": id,
+                    "rounds": rounds,
+                    "round_timeout": round_timeout,
+                },
+                verify=self.verify,
+                headers=self.headers,
+            )
 
         _json = response.json()
 

--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -616,6 +616,13 @@ class APIClient:
         :return: A dict with success or failure message and session config.
         :rtype: dict
         """
+        if model_id is None:
+            response = requests.get(self._get_url_api_v1("models/active"), verify=self.verify, headers=self.headers)
+            if response.status_code == 200:
+                model_id = response.json()
+            else:
+                return response.json()
+
         response = requests.post(
             self._get_url_api_v1("sessions"),
             json={

--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -329,8 +329,18 @@ class APIClient:
         :return: A dict with success or failure message.
         :rtype: dict
         """
+        if path.endswith(".npz"):
+            helper = "numpyhelper"
+        elif path.endswith(".bin"):
+            helper = "binaryhelper"
+
+        if helper:
+            response = requests.put(self._get_url_api_v1("helpers/active"), json={"helper": helper}, verify=self.verify, headers=self.headers)
+
         with open(path, "rb") as file:
-            response = requests.post(self._get_url("set_initial_model"), files={"file": file}, verify=self.verify, headers=self.headers)
+            response = requests.post(
+                self._get_url("set_initial_model"), files={"file": file}, data={"helper": helper}, verify=self.verify, headers=self.headers
+            )
         return response.json()
 
     # --- Packages --- #


### PR DESCRIPTION
The function `start_session` now makes two POST requests in sequence instead of one:
1. `host_url/api/v1/sessions` - to create a session
2. `host_url/api/v1/sessions/start` - to start the session

The 2nd request is made only if the 1st request returns status code 201, indicating that the session has been created, and the response from the 2nd request is returned. Otherwise, the response from the 1st request is returned.

Also, the method `set_active_model` in APIClient now sets the active helper based on the file extension of the seed model file used (".npz" -> numpyhelper, ".bin" -> binaryhelper)