### PR TITLE
Fix/SK-1231 | URL "sessions" -> "sessions/" in APIClient

### DIFF
--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -624,7 +624,7 @@ class APIClient:
                 return response.json()
 
         response = requests.post(
-            self._get_url_api_v1("sessions"),
+            self._get_url_api_v1("sessions/"),
             json={
                 "session_id": id,
                 "session_config": {


### PR DESCRIPTION
Making a POST request to "sessions" gives 404. 

Adding "/" at the end of the URL in APIClient.start_session() to fix the issue.