### PR TITLE
Bugfix/SK-1240 | Add sender to status message in TaskStream

### DIFF
--- a/fedn/network/combiner/combiner.py
+++ b/fedn/network/combiner/combiner.py
@@ -726,6 +726,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         status = fedn.Status(status="Client {} disconnected from TaskStream.".format(client.name))
         status.log_level = fedn.Status.INFO
         status.timestamp.GetCurrentTime()
+        self.__whoami(status.sender, self)
         self._send_status(status)
 
     def SendModelUpdate(self, request, context):


### PR DESCRIPTION
Add sender to status mesaage when client disconnects from TaskStream, causing error in displaying Events in Studio. 