### PR TITLE
Bugfix/SK-1242 | Only access created session if it is successfully created

### DIFF
--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -645,10 +645,9 @@ class APIClient:
             headers=self.headers,
         )
 
-        if id is None:
-            id = response.json()["session_id"]
-
         if response.status_code == 201:
+            if id is None:
+                id = response.json()["session_id"]
             response = requests.post(
                 self._get_url_api_v1("sessions/start"),
                 json={


### PR DESCRIPTION
In APIClient.start_session: Only get session_id from POST response if request is successful. 

This makes the response from the function easier to understand when function fails to create a new session.