### PR TITLE
Fix/SK-1318 | Fixed critical security vulnerability #847 (zlib)

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -67,7 +67,7 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
         with:
-          image-ref: ghcr.io/${{ github.repository }}/fedn:master
+          image-ref: ghcr.io/${{ github.repository }}/fedn:fix-SK-1318
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: HIGH,CRITICAL

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -69,6 +69,7 @@ jobs:
           output: 'trivy-results.sarif'
           severity: HIGH,CRITICAL
           vuln-type: 'os,library'
+          clear-cache: true
           github-pat: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -64,7 +64,7 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
         with:
-          image-ref: ghcr.io/${{ github.repository }}/fedn:fix-SK-1318
+          image-ref: ghcr.io/${{ github.repository }}/fedn:master
           format: 'sarif'
           output: 'trivy-results.sarif'
           severity: HIGH,CRITICAL

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -55,6 +55,9 @@ jobs:
           labels: ${{ steps.meta1.outputs.labels }}
           file: Dockerfile
       
+      - name: Update Trivy database
+        run: trivy --cache-dir /tmp/trivy-db --update
+
       # if push to master of release, run trivy scan on the image
       - name: Trivy scan
         # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -69,7 +72,6 @@ jobs:
           output: 'trivy-results.sarif'
           severity: HIGH,CRITICAL
           vuln-type: 'os,library'
-          clear-cache: true
           github-pat: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Upload Trivy scan results to GitHub Security tab

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -6,6 +6,7 @@ on:
     branches:
       - master
       - develop
+      - fix/SK-1318
   pull_request:
     branches:
       - develop
@@ -56,7 +57,8 @@ jobs:
       
       # if push to master of release, run trivy scan on the image
       - name: Trivy scan
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/fix/SK-1318' }}
         uses: aquasecurity/trivy-action@0.28.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -73,6 +73,7 @@ jobs:
       
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/fix/SK-1318' }}
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -54,9 +54,6 @@ jobs:
           tags: ${{ steps.meta1.outputs.tags }}
           labels: ${{ steps.meta1.outputs.labels }}
           file: Dockerfile
-      
-      - name: Update Trivy database
-        run: trivy --cache-dir /tmp/trivy-db --update
 
       # if push to master of release, run trivy scan on the image
       - name: Trivy scan

--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -6,7 +6,6 @@ on:
     branches:
       - master
       - develop
-      - fix/SK-1318
   pull_request:
     branches:
       - develop
@@ -57,8 +56,7 @@ jobs:
 
       # if push to master of release, run trivy scan on the image
       - name: Trivy scan
-        # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/fix/SK-1318' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         uses: aquasecurity/trivy-action@0.28.0
         env:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
@@ -73,7 +71,6 @@ jobs:
       
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v3
-        # if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/fix/SK-1318' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,9 @@
+# zlib version 1:1.3.dfsg+really1.3.1-1+b1 is installed from Debian Trixie repository,
+# but Trivy assumes an older version of zlib because base image uses Debian Bookworm and
+# therefore raises the vulnerability alert CVE-2023-45853.
+# 
+# See this discussion about a similar issue: https://github.com/aquasecurity/trivy/discussions/6059
+# 
+# Ignoring this vulnerability since it is fixed.
+# 
+CVE-2023-45853

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,9 +1,9 @@
-# zlib version 1:1.3.dfsg+really1.3.1-1+b1 is installed from Debian Trixie repository,
+# zlib version 1:1.3.dfsg+really1.3.1-1+b1 is installed from Debian Testing (Trixie) repository,
 # but Trivy assumes an older version of zlib because base image uses Debian Bookworm and
 # therefore raises the vulnerability alert CVE-2023-45853.
 # 
 # See this discussion about a similar issue: https://github.com/aquasecurity/trivy/discussions/6059
 # 
-# Ignoring this vulnerability since it is fixed.
+# Ignoring this vulnerability since it is fixed in this PR: https://github.com/scaleoutsystems/fedn/pull/787
 # 
 CVE-2023-45853

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,6 +66,9 @@ RUN set -ex \
   && apt-get autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
+
+RUN dpkg -l | grep zlib
+
 USER appuser
 
 ENTRYPOINT [ "/venv/bin/fedn" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,8 @@ RUN set -ex \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
+RUN dpkg -l | grep zlib
+
 USER appuser
 
 ENTRYPOINT [ "/venv/bin/fedn" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Builder
 ARG BASE_IMG=python:3.12-slim
-FROM $BASE_IMG as builder
+FROM $BASE_IMG AS builder
 
 ARG GRPC_HEALTH_PROBE_VERSION=""
 ARG REQUIREMENTS=""

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,8 +71,6 @@ RUN set -ex \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
 
-RUN dpkg -l | grep zlib
-
 USER appuser
 
 ENTRYPOINT [ "/venv/bin/fedn" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,14 @@ ARG REQUIREMENTS=""
 
 WORKDIR /build
 
+# Temporarily add the testing repository to install zlib1g 1.3.1
+RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends -t testing zlib1g=1:1.3.dfsg+really1.3.1-1+b1 zlib1g-dev=1:1.3.dfsg+really1.3.1-1+b1 \
+  && rm -rf /etc/apt/sources.list.d/testing.list \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install build dependencies
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python3-dev gcc wget \
   && rm -rf /var/lib/apt/lists/*
@@ -49,9 +57,12 @@ RUN set -ex \
   # Creare application specific tmp directory, set ENV TMPDIR to /app/tmp
   && mkdir -p /app/tmp \
   && chown -R appuser:appgroup /venv /app \
-  # Upgrade the package index and install security upgrades
+  # Temporarily add the testing repository to install zlib 1.3.1
+  && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list \
   && apt-get update \
-  && apt-get upgrade -y \
+  && apt-get install -y --no-install-recommends -t testing zlib1g=1:1.3.dfsg+really1.3.1-1+b1 \
+  && rm -rf /etc/apt/sources.list.d/testing.list \
+  # Clean up
   && apt-get autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,8 @@ ARG REQUIREMENTS=""
 
 WORKDIR /build
 
-# Temporarily add the testing repository to install zlib1g 1.3.1
+# Temporarily add the Debian Testing repository to install zlib1g 1:1.3.dfsg+really1.3.1-1+b1 (fixed CVE-2023-45853)
+# Both zlib1g and zlib1g-dev are installed in the builder stage.
 RUN echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list \
   && apt-get update \
   && apt-get install -y --no-install-recommends -t testing zlib1g=1:1.3.dfsg+really1.3.1-1+b1 zlib1g-dev=1:1.3.dfsg+really1.3.1-1+b1 \
@@ -57,17 +58,18 @@ RUN set -ex \
   # Creare application specific tmp directory, set ENV TMPDIR to /app/tmp
   && mkdir -p /app/tmp \
   && chown -R appuser:appgroup /venv /app \
-  # Temporarily add the testing repository to install zlib 1.3.1
+  # Temporarily add the Debian Testing repository to install zlib1g 1:1.3.dfsg+really1.3.1-1+b1 (fixed CVE-2023-45853)
   && echo "deb http://deb.debian.org/debian testing main" > /etc/apt/sources.list.d/testing.list \
   && apt-get update \
   && apt-get install -y --no-install-recommends -t testing zlib1g=1:1.3.dfsg+really1.3.1-1+b1 \
   && rm -rf /etc/apt/sources.list.d/testing.list \
+  # Update package index and upgrade all installed packages
+  && apt-get update \
+  && apt-get upgrade -y \
   # Clean up
   && apt-get autoremove -y \
   && apt-get clean -y \
   && rm -rf /var/lib/apt/lists/*
-
-RUN dpkg -l | grep zlib
 
 USER appuser
 


### PR DESCRIPTION
This PR fixes the critical security vulnerability [CVE-2023-45853](https://avd.aquasec.com/nvd/2023/cve-2023-45853/). Code scanning alert on GitHub [here](https://github.com/scaleoutsystems/fedn/security/code-scanning/847). 

The vulnerability arises because Debian Bookworm uses an old version (1:1.2.13.dfsg-1) of the C library zlib (used for handling zip files). This version of zlib has a vulnerability which is fixed in version 1:1.3.dfsg+really1.3.1-1+b1 ([Debian Security Tracker](https://security-tracker.debian.org/tracker/source-package/zlib)).

**Solution:**
* Temporarily add the Debian Testing (Trixie) repo in the builder and runtime stages, which includes the fixed version of zlib
* Install the fixed version of zlib
* Remove the Debian Testing repo

**Note**
Trivy doesn't pick up on this solution. It sees that Debian Bookworm is used, and assumes that the vulnerable version (1:1.2.13.dfsg-1) of zlib is installed. Therefor this vulnerability ID has been added to `.trivyignore`, since we know that it has been fixed. See this [discussion](https://github.com/aquasecurity/trivy/discussions/6059) on Trivy's GitHub about solving this problem.