### PR TITLE
Fix/SK-1323 | fixed default host in shared.py

### DIFF
--- a/fedn/cli/login_cmd.py
+++ b/fedn/cli/login_cmd.py
@@ -32,13 +32,10 @@ def login_cmd(ctx, protocol: str, host: str, username: str, password: str):
     url = f"{protocol}://{host}/api/token/"
 
     # Step 3: Prompt for username and password
-    if username is None and password is None:
+    if username is None:
         username = input("Please enter your username: ")
+    if password is None:
         password = getpass("Please enter your password: ")
-    elif password is None:
-        password = getpass("Please enter your password: ")
-    else:
-        username = input("Please enter your username: ")
 
     # Call the authentication API
     try:

--- a/fedn/cli/shared.py
+++ b/fedn/cli/shared.py
@@ -8,7 +8,7 @@ from fedn.common.log_config import logger
 
 CONTROLLER_DEFAULTS = {"protocol": "http", "host": "localhost", "port": 8092, "debug": False}
 
-STUDIO_DEFAULTS = {"protocol": "https", "host": "fedn.scaleoutstudio.com"}
+STUDIO_DEFAULTS = {"protocol": "https", "host": "fedn.scaleoutsystems.com"}
 
 COMBINER_DEFAULTS = {"discover_host": "localhost", "discover_port": 8092, "host": "localhost", "port": 12080, "name": "combiner", "max_clients": 30}
 


### PR DESCRIPTION
This pull request includes changes to improve the login command and update default settings in the `fedn` CLI. The most important changes include modifying the login prompt logic and updating the default host for the studio configuration.

Improvements to login command:

* [`fedn/cli/login_cmd.py`](diffhunk://#diff-9788be9f9838bc07ce22a0622faa4bda983da1538ffd55ae5d06c1f5008f4519L35-L41): Simplified the logic for prompting the user to enter their username and password by removing redundant conditions.

Updates to default settings:

* [`fedn/cli/shared.py`](diffhunk://#diff-228df46d4684693377c73df317ab0600f79b09ac3462ff742546e245ae6f6a5dL11-R11): Updated the default host for the studio configuration from `fedn.scaleoutstudio.com` to `fedn.scaleoutsystems.com`.