### PR TITLE
Fix/SK-1325 | JWT role "admin" -> "client" for client endpoints

### DIFF
--- a/fedn/network/api/v1/client_routes.py
+++ b/fedn/network/api/v1/client_routes.py
@@ -404,7 +404,7 @@ def delete_client(id: str):
 
 
 @bp.route("/add", methods=["POST"])
-@jwt_auth_required(role="admin")
+@jwt_auth_required(role="client")
 def add_client():
     """Add client
     Adds a client to the network.

--- a/fedn/network/api/v1/package_routes.py
+++ b/fedn/network/api/v1/package_routes.py
@@ -6,9 +6,8 @@ from werkzeug.security import safe_join
 
 from fedn.common.config import FEDN_COMPUTE_PACKAGE_DIR
 from fedn.network.api.auth import jwt_auth_required
-from fedn.network.api.shared import control
+from fedn.network.api.shared import control, package_store, repository
 from fedn.network.api.shared import get_checksum as _get_checksum
-from fedn.network.api.shared import package_store, repository
 from fedn.network.api.v1.shared import api_version, get_post_data_to_kwargs, get_typed_list_headers
 from fedn.network.storage.statestore.stores.shared import EntityNotFound
 
@@ -573,7 +572,7 @@ def upload_package():
 
 
 @bp.route("/download", methods=["GET"])
-@jwt_auth_required(role="admin")
+@jwt_auth_required(role="client")
 def download_package():
     """Download package
     Downloads a package based on the provided id.


### PR DESCRIPTION
Changed required role from "admin" to "client" for enpoints clients/add and packages/download (same as the old endpoints in server.py).