### PR TITLE
Bugfix/SK-1253 | Client exit if no python_env is defined in fedn.yaml

### DIFF
--- a/fedn/network/clients/fedn_client.py
+++ b/fedn/network/clients/fedn_client.py
@@ -420,10 +420,6 @@ class FednClient:
 
         result = self.get_or_set_environment()
 
-        if not result:
-            logger.error("Could not set environment")
-            return False
-
         return True
 
     def init_local_compute_package(self):
@@ -435,10 +431,6 @@ class FednClient:
             return False
 
         result = self.get_or_set_environment()
-
-        if not result:
-            logger.error("Could not set environment")
-            return False
 
         logger.info("Dispatcher set")
 


### PR DESCRIPTION
If python_env is removed from fedn.yaml the client will exit and assume there should always be an env. This is not the expected behavior. python_env is an optional feature. 

This PR fixes that. 