### PR TITLE
Feature/SK-1339 | Add predictions (list etc) to APIClient

### DIFF
--- a/examples/mnist-pytorch/client/predict.py
+++ b/examples/mnist-pytorch/client/predict.py
@@ -5,23 +5,24 @@ import torch
 from data import load_data
 from model import load_parameters
 
+from fedn.utils.helpers.helpers import save_metrics
+
 dir_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.append(os.path.abspath(dir_path))
 
 
-def predict(in_model_path, out_artifact_path, data_path=None):
+def predict(in_model_path, out_json_path, data_path=None):
     """Validate model.
 
     :param in_model_path: The path to the input model.
     :type in_model_path: str
-    :param out_artifact_path: The path to save the predict output to.
-    :type out_artifact_path: str
+    :param out_json_path: The path to save the predict output to.
+    :type out_json_path: str
     :param data_path: The path to the data file.
     :type data_path: str
     """
     # Load data
     x_test, y_test = load_data(data_path, is_train=False)
-
     # Load model
     model = load_parameters(in_model_path)
     model.eval()
@@ -29,8 +30,11 @@ def predict(in_model_path, out_artifact_path, data_path=None):
     # Predict
     with torch.no_grad():
         y_pred = model(x_test)
-    # Save prediction to file/artifact, the artifact will be uploaded to the object store by the client
-    torch.save(y_pred, out_artifact_path)
+        y_pred = torch.argmax(y_pred, dim=1)
+
+    result = {"predicted_class": y_pred.tolist()}
+
+    save_metrics(result, out_json_path)
 
 
 if __name__ == "__main__":

--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -1,5 +1,6 @@
 import inspect
 import os
+import uuid
 
 import requests
 
@@ -879,6 +880,29 @@ class APIClient:
             _headers["X-Limit"] = str(n_max)
 
         response = requests.get(self._get_url_api_v1("predictions/"), params=_params, verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json
+
+    def start_predictions(self, prediction_id: str = None, model_id: str = None):
+        """Start predictions for a model.
+
+        :param model_id: The model id to start predictions for.
+        :type model_id: str
+        :param data: The data to predict.
+        :type data: dict
+        :return: A dict with success or failure message.
+        :rtype: dict
+        """
+        if not prediction_id:
+            prediction_id = str(uuid.uuid4())
+        response = requests.post(
+            self._get_url_api_v1("predictions/start"),
+            json={"prediction_id": prediction_id, "model_id": model_id},
+            verify=self.verify,
+            headers=self.headers,
+        )
 
         _json = response.json()
 

--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -821,3 +821,65 @@ class APIClient:
         _json = response.json()
 
         return _json
+
+    # --- Predictions --- #
+
+    def get_predictions(
+        self,
+        model_id: str = None,
+        correlation_id: str = None,
+        sender_name: str = None,
+        sender_role: str = None,
+        receiver_name: str = None,
+        receiver_role: str = None,
+        n_max: int = None,
+    ):
+        """Get predictions from the statestore. Filter by input parameters.
+
+        :param model_id: The model id to get predictions for.
+        :type model_id: str
+        :param correlation_id: The correlation id to get predictions for.
+        :type correlation_id: str
+        :param sender_name: The sender name to get predictions for.
+        :type sender_name: str
+        :param sender_role: The sender role to get predictions for.
+        :type sender_role: str
+        :param receiver_name: The receiver name to get predictions for.
+        :type receiver_name: str
+        :param receiver_role: The receiver role to get predictions for.
+        :type receiver_role: str
+        :param n_max: The maximum number of predictions to get (If none all will be fetched).
+        :type n_max: int
+        :return: Predictions.
+        :rtype: dict
+        """
+        _params = {}
+
+        if model_id:
+            _params["modelId"] = model_id
+
+        if correlation_id:
+            _params["correlationId"] = correlation_id
+
+        if sender_name:
+            _params["sender.name"] = sender_name
+
+        if sender_role:
+            _params["sender.role"] = sender_role
+
+        if receiver_name:
+            _params["receiver.name"] = receiver_name
+
+        if receiver_role:
+            _params["receiver.role"] = receiver_role
+
+        _headers = self.headers.copy()
+
+        if n_max:
+            _headers["X-Limit"] = str(n_max)
+
+        response = requests.get(self._get_url_api_v1("predictions/"), params=_params, verify=self.verify, headers=_headers)
+
+        _json = response.json()
+
+        return _json

--- a/fedn/network/api/v1/prediction_routes.py
+++ b/fedn/network/api/v1/prediction_routes.py
@@ -7,7 +7,7 @@ from fedn.network.api.shared import control, model_store, prediction_store
 from fedn.network.api.v1.shared import api_version, get_post_data_to_kwargs, get_typed_list_headers
 from fedn.network.storage.statestore.stores.shared import EntityNotFound
 
-bp = Blueprint("prediction", __name__, url_prefix=f"/api/{api_version}/predict")
+bp = Blueprint("prediction", __name__, url_prefix=f"/api/{api_version}/predictions")
 
 
 @bp.route("/start", methods=["POST"])

--- a/fedn/network/api/v1/prediction_routes.py
+++ b/fedn/network/api/v1/prediction_routes.py
@@ -26,6 +26,8 @@ def start_session():
         if not prediction_id or prediction_id == "":
             return jsonify({"message": "prediction_id is required"}), 400
 
+        session_config = {"prediction_id": prediction_id}
+
         if data.get("model_id") is None:
             count = model_store.count()
             if count == 0:
@@ -34,10 +36,9 @@ def start_session():
             try:
                 model_id = data.get("model_id")
                 _ = model_store.get(model_id)
+                session_config["model_id"] = model_id
             except EntityNotFound:
                 return jsonify({"message": f"Model {model_id} not found"}), 404
-
-        session_config = {"prediction_id": prediction_id}
 
         threading.Thread(target=control.prediction_session, kwargs={"config": session_config}).start()
 


### PR DESCRIPTION
### Add predictions (list etc) to APIClient

**Changes:**
- mnist-pytorch predict example updated to store json
- name **route change**:  predict => predictions **!OBS**
- list predictions added to api client
- start predictions added to api client