### PR TITLE
Fix/SK-1349 | Return session_id from APIClient.start_session

### DIFF
--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -656,9 +656,11 @@ class APIClient:
                 verify=self.verify,
                 headers=self.headers,
             )
+            response_json = response.json()
+            response_json["session_id"] = session_id
+            return response_json
 
         _json = response.json()
-
         return _json
 
     # --- Statuses --- #


### PR DESCRIPTION
session_id was recently removed as input to start_session, this PR makes the session_id available to the client after having started a session