### PR TITLE
Github/SK-1351 | Move trivy workflow to own file

### DIFF
--- a/.github/workflows/build-containers.yaml
+++ b/.github/workflows/build-containers.yaml
@@ -53,24 +53,3 @@ jobs:
           tags: ${{ steps.meta1.outputs.tags }}
           labels: ${{ steps.meta1.outputs.labels }}
           file: Dockerfile
-
-      # if push to master of release, run trivy scan on the image
-      - name: Trivy scan
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        uses: aquasecurity/trivy-action@0.28.0
-        env:
-          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
-          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
-        with:
-          image-ref: ghcr.io/${{ github.repository }}/fedn:master
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: HIGH,CRITICAL
-          vuln-type: 'os,library'
-          github-pat: ${{ secrets.GITHUB_TOKEN }}
-      
-      - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        with:
-          sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/trivy-scanning.yaml
+++ b/.github/workflows/trivy-scanning.yaml
@@ -1,0 +1,41 @@
+name: Trivy scan
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 0 * * 1'
+
+jobs:
+  trivy_scan:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # for github/codeql-action/upload-sarif to upload SARIF results
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build an image from Dockerfile
+      run: |
+        docker build -t ghcr.io/scaleoutsystems/fedn:${{ github.sha }} .
+
+    - name: Run Trivy vulnerability scanner in docker mode
+      uses: aquasecurity/trivy-action@0.28.0
+      env:
+         TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db,aquasec/trivy-db,ghcr.io/aquasecurity/trivy-db
+         TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db,aquasec/trivy-java-db,ghcr.io/aquasecurity/trivy-java-db
+      with:
+        image-ref: 'ghcr.io/scaleoutsystems/fedn:${{ github.sha }}'
+        format: 'sarif'
+        output: 'trivy-results.sarif'
+        severity: HIGH,CRITICAL
+        vuln-type: 'os,library'
+        github-pat: ${{ secrets.GITHUB_TOKEN }}
+    
+    - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Move the trivy scans out of build-containers workflow and make it its own. This will enable workflow_dispatch also, if onw like to scan an upstream branch.