### PR TITLE
Bug/SK-1410 | Missing / in some endpoints, fixing set_active_model

### DIFF
--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -339,7 +339,7 @@ class APIClient:
             response = requests.put(self._get_url_api_v1("helpers/active"), json={"helper": helper}, verify=self.verify, headers=self.headers)
 
         with open(path, "rb") as file:
-            response = requests.post(self._get_url_api_v1("models"), files={"file": file}, data={"helper": helper}, verify=self.verify, headers=self.headers)
+            response = requests.post(self._get_url_api_v1("models/"), files={"file": file}, data={"helper": helper}, verify=self.verify, headers=self.headers)
         return response.json()
 
     # --- Packages --- #
@@ -441,7 +441,7 @@ class APIClient:
         """
         with open(path, "rb") as file:
             response = requests.post(
-                self._get_url_api_v1("packages"),
+                self._get_url_api_v1("packages/"),
                 files={"file": file},
                 data={"helper": helper, "name": name, "description": description},
                 verify=self.verify,


### PR DESCRIPTION
This pull request includes changes to the `fedn/network/api/client.py` file to ensure consistency in the API endpoints used in the `set_active_model` and `set_active_package` methods.

API endpoint consistency:

* [`fedn/network/api/client.py`](diffhunk://#diff-5f9f034de62a708decc2767d15fc7b2076a8322545873ec6121c9fd62d4658f8L342-R342): Modified the `set_active_model` method to use the endpoint `models/` instead of `models`.
* [`fedn/network/api/client.py`](diffhunk://#diff-5f9f034de62a708decc2767d15fc7b2076a8322545873ec6121c9fd62d4658f8L444-R444): Modified the `set_active_package` method to use the endpoint `packages/` instead of `packages`.