### PR TITLE
Bugfix/SK-1421 | Change load_data function in HuggingFace example

### DIFF
--- a/examples/huggingface/client/data.py
+++ b/examples/huggingface/client/data.py
@@ -11,7 +11,7 @@ abs_path = os.path.abspath(dir_path)
 def load_data(data_path=None, is_train=True):
     if data_path is None:
         data_path = os.environ.get("FEDN_DATA_PATH", abs_path + "/data/clients/1/enron_spam.pt")
-    data = torch.load(data_path, weights_only=True)
+    data = torch.load(data_path, weights_only=False)
     if is_train:
         X = data["X_train"]
         y = data["y_train"]


### PR DESCRIPTION
This PR sets weights_only to False in the torch.load function. 
Weights_only=True gave an UnpicklingError.