### PR TITLE
Bugfix/SK-1440 | Syntax error escape character on windows paths

### DIFF
--- a/fedn/network/clients/package_runtime.py
+++ b/fedn/network/clients/package_runtime.py
@@ -123,17 +123,17 @@ class PackageRuntime:
                 with tarfile.open(os.path.join(self.pkg_path, self.pkg_name), "r:*") as f:
                     for member in f.getmembers():
                         f.extract(member, self.pkg_path)
-                    logger.info(f"Successfully extracted compute package content in {self.pkg_path}")
-                    logger.info("Deleting temporary package tarball file.")
-                    os.remove(os.path.join(self.pkg_path, self.pkg_name))
+                logger.info(f"Successfully extracted compute package content in {self.pkg_path}")
+                logger.info("Deleting temporary package tarball file.")
+                os.remove(os.path.join(self.pkg_path, self.pkg_name))
 
-                    for root, _, files in os.walk(os.path.join(self.pkg_path, "")):
-                        if "fedn.yaml" in files:
-                            logger.info(f"Found fedn.yaml file in {root}")
-                            return True, root
+                for root, _, files in os.walk(os.path.join(self.pkg_path, "")):
+                    if "fedn.yaml" in files:
+                        logger.info(f"Found fedn.yaml file in {root}")
+                        return True, root
 
-                    logger.error("No fedn.yaml file found in extracted package!")
-                    return False, ""
+                logger.error("No fedn.yaml file found in extracted package!")
+                return False, ""
         except Exception as e:
             logger.error(f"Error extracting files: {e}")
             os.remove(os.path.join(self.pkg_path, self.pkg_name))

--- a/fedn/network/clients/package_runtime.py
+++ b/fedn/network/clients/package_runtime.py
@@ -127,15 +127,15 @@ class PackageRuntime:
                     logger.info("Deleting temporary package tarball file.")
                     os.remove(os.path.join(self.pkg_path, self.pkg_name))
 
-                    for root, _, files in os.walk(self.pkg_path):
+                    for root, _, files in os.walk(os.path.join(self.pkg_path, "")):
                         if "fedn.yaml" in files:
                             logger.info(f"Found fedn.yaml file in {root}")
                             return True, root
 
                     logger.error("No fedn.yaml file found in extracted package!")
                     return False, ""
-        except Exception:
-            logger.error("Error extracting files.")
+        except Exception as e:
+            logger.error(f"Error extracting files: {e}")
             os.remove(os.path.join(self.pkg_path, self.pkg_name))
             return False, ""
 
@@ -150,5 +150,6 @@ class PackageRuntime:
         try:
             self.dispatch_config = _read_yaml_file(os.path.join(run_path, "fedn.yaml"))
             return Dispatcher(self.dispatch_config, run_path)
-        except Exception:
+        except Exception as e:
+            logger.error(f"Error getting dispatcher: {e}")
             return None


### PR DESCRIPTION
Escape chars (back slash) raised error because os.path.join was not used in os.walk to find fedn.yaml, further trying to delete the pacjage tar while it was in with clause. This PR fixes that. 