### PR TITLE
Bugfix/SK-1452 | GrpcConnectionOptions all args not needed for direct combiner connection

### DIFF
--- a/fedn/network/clients/fedn_client.py
+++ b/fedn/network/clients/fedn_client.py
@@ -12,8 +12,7 @@ from typing import Any, Optional, Tuple, Union
 import requests
 
 import fedn.network.grpc.fedn_pb2 as fedn
-from fedn.common.config import (FEDN_AUTH_SCHEME, FEDN_CONNECT_API_SECURE,
-                                FEDN_PACKAGE_EXTRACT_DIR)
+from fedn.common.config import FEDN_AUTH_SCHEME, FEDN_CONNECT_API_SECURE, FEDN_PACKAGE_EXTRACT_DIR
 from fedn.common.log_config import logger
 from fedn.network.clients.grpc_handler import GrpcHandler
 from fedn.network.clients.package_runtime import PackageRuntime
@@ -34,7 +33,7 @@ REQUEST_TIMEOUT = 10  # seconds
 class GrpcConnectionOptions:
     """Options for configuring the GRPC connection."""
 
-    def __init__(self, status: str, host: str, fqdn: str, package: str, ip: str, port: int, helper_type: str) -> None:
+    def __init__(self, host: str, port: int, status: str = "", fqdn: str = "", package: str = "", ip: str = "", helper_type: str = "") -> None:
         """Initialize GrpcConnectionOptions."""
         self.status = status
         self.host = host
@@ -124,7 +123,7 @@ class FednClient:
                 allow_redirects=True,
                 headers={"Authorization": f"{FEDN_AUTH_SCHEME} {token}"},
                 timeout=REQUEST_TIMEOUT,
-                verify=FEDN_CONNECT_API_SECURE
+                verify=FEDN_CONNECT_API_SECURE,
             )
 
             if response.status_code == HTTP_STATUS_OK:


### PR DESCRIPTION
GRPCConnectionOptions returned missing constructor arguments error when connecting directly to combiner without service discovery at controller, i.e --combiner and --combiner-port in CLI.