### PR TITLE
Bug/SK-1469 | Fixed bug with prediction not using the client subselection

### DIFF
--- a/fedn/network/combiner/combiner.py
+++ b/fedn/network/combiner/combiner.py
@@ -222,7 +222,7 @@ class Combiner(rpc.CombinerServicer, rpc.ReducerServicer, rpc.ConnectorServicer,
         :type clients: list
 
         """
-        clients = self._send_request_type(fedn.StatusType.MODEL_PREDICTION, prediction_id, model_id, clients)
+        clients = self._send_request_type(fedn.StatusType.MODEL_PREDICTION, prediction_id, model_id, {}, clients)
 
         if len(clients) < 20:
             logger.info("Sent model prediction request for model {} to clients {}".format(model_id, clients))


### PR DESCRIPTION
This pull request includes a modification to the `request_model_prediction` method in the `fedn/network/combiner/combiner.py` file to correct the handling of client requests. An empty dict is used as config so that the positional inputs are correct. 
