### PR TITLE
Feature/SK-1510 | Add ENV for setting home dir

### DIFF
--- a/fedn/cli/login_cmd.py
+++ b/fedn/cli/login_cmd.py
@@ -5,10 +5,7 @@ import click
 import requests
 
 from .main import main
-from .shared import STUDIO_DEFAULTS, get_response, set_context
-
-# Replace this with the platform's actual login endpoint
-home_dir = os.path.expanduser("~")
+from .shared import HOME_DIR, STUDIO_DEFAULTS, get_response, set_context
 
 
 @main.group("studio")
@@ -50,7 +47,7 @@ def login_cmd(ctx, protocol: str, host: str, username: str, password: str):
     if response.status_code == 200:
         context_data = get_context(response, protocol, host)
 
-        context_path = os.path.join(home_dir, ".fedn")
+        context_path = os.path.join(HOME_DIR, ".fedn")
         if not os.path.exists(context_path):
             os.makedirs(context_path)
         set_context(context_path, context_data)

--- a/fedn/cli/project_cmd.py
+++ b/fedn/cli/project_cmd.py
@@ -4,9 +4,7 @@ import click
 import requests
 
 from .main import main
-from .shared import STUDIO_DEFAULTS, get_api_url, get_context, get_response, get_token, print_response, set_context
-
-home_dir = os.path.expanduser("~")
+from .shared import HOME_DIR, STUDIO_DEFAULTS, get_api_url, get_context, get_response, get_token, print_response, set_context
 
 
 @main.group("project")
@@ -109,7 +107,7 @@ def list_projects(ctx, protocol: str = None, host: str = None):
     if response.status_code == 200:
         response_json = response.json()
         if len(response_json) > 0:
-            context_path = os.path.join(home_dir, ".fedn")
+            context_path = os.path.join(HOME_DIR, ".fedn")
             context_data = get_context(context_path)
             active_project = context_data.get("Active project id")
 
@@ -167,7 +165,7 @@ def activate_project(id: str = None, protocol: str = None, host: str = None):
     """Sets project with give ID as active by updating context file."""
     studio_api = True
     headers_projects = {}
-    context_path = os.path.join(home_dir, ".fedn")
+    context_path = os.path.join(HOME_DIR, ".fedn")
     context_data = get_context(context_path)
 
     user_access_token = context_data.get("User tokens").get("access")

--- a/fedn/cli/shared.py
+++ b/fedn/cli/shared.py
@@ -12,14 +12,14 @@ STUDIO_DEFAULTS = {"protocol": "https", "host": "api.fedn.scaleoutsystems.com"}
 
 COMBINER_DEFAULTS = {"discover_host": "localhost", "discover_port": 8092, "host": "localhost", "port": 12080, "name": "combiner", "max_clients": 30}
 
+HOME_DIR = os.environ.get("FEDN_HOME_DIR", os.path.expanduser("~"))
+
 CLIENT_DEFAULTS = {
     "discover_host": "localhost",
     "discover_port": 8092,
 }
 
 API_VERSION = "v1"
-
-home_dir = os.path.expanduser("~")
 
 
 def apply_config(path: str, config: dict):
@@ -57,7 +57,7 @@ def get_api_url(protocol: str, host: str, port: str, endpoint: str, usr_api: boo
 def get_project_url(protocol: str, host: str, port: str, endpoint: str) -> str:
     _url = os.environ.get("FEDN_CONTROLLER_URL")
     if _url is None:
-        context_path = os.path.join(home_dir, ".fedn")
+        context_path = os.path.join(HOME_DIR, ".fedn")
         try:
             context_data = get_context(context_path)
             _url = context_data.get("Active project url")
@@ -74,7 +74,7 @@ def get_token(token: str, usr_token: bool) -> str:
     _token = token or os.environ.get("FEDN_AUTH_TOKEN", None)
 
     if _token is None:
-        context_path = os.path.join(home_dir, ".fedn")
+        context_path = os.path.join(HOME_DIR, ".fedn")
         try:
             context_data = get_context(context_path)
             if usr_token:


### PR DESCRIPTION
This pull request includes several changes to the `fedn/cli` module, aimed at improving code consistency and maintainability by centralizing the definition of the home directory path. The most important changes include replacing the `home_dir` variable with the newly introduced `HOME_DIR` constant across multiple files and functions.

Centralization of home directory path:

* [`fedn/cli/shared.py`](diffhunk://#diff-228df46d4684693377c73df317ab0600f79b09ac3462ff742546e245ae6f6a5dR15-L23): Introduced `HOME_DIR` constant to replace the `home_dir` variable. (`[fedn/cli/shared.pyR15-L23](diffhunk://#diff-228df46d4684693377c73df317ab0600f79b09ac3462ff742546e245ae6f6a5dR15-L23)`)

Updates to use `HOME_DIR`:

* [`fedn/cli/login_cmd.py`](diffhunk://#diff-9788be9f9838bc07ce22a0622faa4bda983da1538ffd55ae5d06c1f5008f4519L8-R8): Replaced `home_dir` with `HOME_DIR` in the `login_cmd` function and adjusted imports accordingly. (`[[1]](diffhunk://#diff-9788be9f9838bc07ce22a0622faa4bda983da1538ffd55ae5d06c1f5008f4519L8-R8)`, `[[2]](diffhunk://#diff-9788be9f9838bc07ce22a0622faa4bda983da1538ffd55ae5d06c1f5008f4519L53-R50)`)
* [`fedn/cli/project_cmd.py`](diffhunk://#diff-47b8804071930af2cb35c0fe55681e310788446fd1a2f8886bbce2c03b3cd904L7-R7): Replaced `home_dir` with `HOME_DIR` in the `list_projects` and `activate_project` functions and adjusted imports accordingly. (`[[1]](diffhunk://#diff-47b8804071930af2cb35c0fe55681e310788446fd1a2f8886bbce2c03b3cd904L7-R7)`, `[[2]](diffhunk://#diff-47b8804071930af2cb35c0fe55681e310788446fd1a2f8886bbce2c03b3cd904L112-R110)`, `[[3]](diffhunk://#diff-47b8804071930af2cb35c0fe55681e310788446fd1a2f8886bbce2c03b3cd904L170-R168)`)
* [`fedn/cli/shared.py`](diffhunk://#diff-228df46d4684693377c73df317ab0600f79b09ac3462ff742546e245ae6f6a5dL60-R60): Replaced `home_dir` with `HOME_DIR` in the `get_project_url` and `get_token` functions. (`[[1]](diffhunk://#diff-228df46d4684693377c73df317ab0600f79b09ac3462ff742546e245ae6f6a5dL60-R60)`, `[[2]](diffhunk://#diff-228df46d4684693377c73df317ab0600f79b09ac3462ff742546e245ae6f6a5dL77-R77)`)