### PR TITLE
Feature/SK-1381 | Add committed_at as a field for all table stores and use this as a base for all orderings

### DIFF
--- a/fedn/network/storage/statestore/stores/attribute_store.py
+++ b/fedn/network/storage/statestore/stores/attribute_store.py
@@ -48,7 +48,7 @@ def _translate_key_sql(key: str):
 
 class SQLAttributeStore(AttributeStore, SQLStore[AttributeDTO, AttributeModel]):
     def __init__(self, session):
-        super().__init__(session, AttributeModel)
+        super().__init__(session, AttributeModel, "attribute_id")
 
     def list(self, limit=0, skip=0, sort_key=None, sort_order=SortOrder.DESCENDING, **kwargs):
         sort_key = _translate_key_sql(sort_key)

--- a/fedn/network/storage/statestore/stores/client_store.py
+++ b/fedn/network/storage/statestore/stores/client_store.py
@@ -66,7 +66,7 @@ class MongoDBClientStore(ClientStore, MongoDBStore[ClientDTO]):
 
 class SQLClientStore(ClientStore, SQLStore[ClientDTO, ClientModel]):
     def __init__(self, Session):
-        super().__init__(Session, ClientModel)
+        super().__init__(Session, ClientModel, "client_id")
 
     def update(self, item: ClientDTO) -> ClientDTO:
         return self.sql_update(item)

--- a/fedn/network/storage/statestore/stores/combiner_store.py
+++ b/fedn/network/storage/statestore/stores/combiner_store.py
@@ -34,7 +34,7 @@ class MongoDBCombinerStore(CombinerStore, MongoDBStore[CombinerDTO]):
 
 class SQLCombinerStore(CombinerStore, SQLStore[CombinerDTO, CombinerModel]):
     def __init__(self, Session):
-        super().__init__(Session, CombinerModel)
+        super().__init__(Session, CombinerModel, "combiner_id")
 
     def get_by_name(self, name: str) -> CombinerDTO:
         with self.Session() as session:

--- a/fedn/network/storage/statestore/stores/dto/shared.py
+++ b/fedn/network/storage/statestore/stores/dto/shared.py
@@ -361,6 +361,15 @@ class BaseDTO(DictDTO):
                         return getattr(self, key)
         raise AttributeError(f"{self.__class__.__name__} has no field of type PrimaryID")
 
+    def primary_key(self) -> str:
+        """Get the key of the primary id."""
+        for base in self.__class__.__mro__:
+            if hasattr(base, "__dict__"):
+                for key in base.__dict__.keys():
+                    if isinstance(getattr(self.__class__, key), PrimaryID):
+                        return key
+        raise AttributeError(f"{self.__class__.__name__} has no field of type PrimaryID")
+
     def _is_field_optional(self, key):
         return super()._is_field_optional(key) or key == "committed_at"
 

--- a/fedn/network/storage/statestore/stores/metric_store.py
+++ b/fedn/network/storage/statestore/stores/metric_store.py
@@ -35,7 +35,7 @@ def _translate_key_sql(key: str):
 
 class SQLMetricStore(MetricStore, SQLStore[MetricDTO, MetricModel]):
     def __init__(self, session):
-        super().__init__(session, MetricModel)
+        super().__init__(session, MetricModel, "metric_id")
 
     def list(self, limit=0, skip=0, sort_key=None, sort_order=SortOrder.DESCENDING, **kwargs):
         sort_key = _translate_key_sql(sort_key)

--- a/fedn/network/storage/statestore/stores/model_store.py
+++ b/fedn/network/storage/statestore/stores/model_store.py
@@ -206,7 +206,7 @@ class MongoDBModelStore(ModelStore, MongoDBStore[ModelDTO]):
 
 class SQLModelStore(ModelStore, SQLStore[ModelDTO, ModelModel]):
     def __init__(self, Session):
-        super().__init__(Session, ModelModel)
+        super().__init__(Session, ModelModel, "model_id")
 
     def update(self, item: ModelDTO) -> ModelDTO:
         return self.sql_update(item)

--- a/fedn/network/storage/statestore/stores/package_store.py
+++ b/fedn/network/storage/statestore/stores/package_store.py
@@ -163,7 +163,7 @@ class MongoDBPackageStore(PackageStore, MongoDBStore[PackageDTO]):
 
 class SQLPackageStore(PackageStore, SQLStore[PackageDTO, PackageModel]):
     def __init__(self, Session):
-        super().__init__(Session, PackageModel)
+        super().__init__(Session, PackageModel, "package_id")
 
     def set_active(self, id: str):
         with self.Session() as session:

--- a/fedn/network/storage/statestore/stores/prediction_store.py
+++ b/fedn/network/storage/statestore/stores/prediction_store.py
@@ -44,7 +44,7 @@ def _translate_key_sql(key: str):
 
 class SQLPredictionStore(PredictionStore, SQLStore[PredictionDTO, PredictionModel]):
     def __init__(self, Session):
-        super().__init__(Session, PredictionModel)
+        super().__init__(Session, PredictionModel, "prediction_id")
 
     def list(self, limit: int = 0, skip: int = 0, sort_key: str = None, sort_order=SortOrder.DESCENDING, **kwargs) -> List[PredictionDTO]:
         kwargs = {_translate_key_sql(k): v for k, v in kwargs.items()}

--- a/fedn/network/storage/statestore/stores/round_store.py
+++ b/fedn/network/storage/statestore/stores/round_store.py
@@ -46,7 +46,7 @@ class MongoDBRoundStore(RoundStore, MongoDBStore[RoundDTO]):
 
 class SQLRoundStore(RoundStore, SQLStore[RoundDTO, RoundModel]):
     def __init__(self, Session):
-        super().__init__(Session, RoundModel)
+        super().__init__(Session, RoundModel, "round_id")
 
     def update(self, item: RoundDTO) -> RoundDTO:
         return self.sql_update(item)

--- a/fedn/network/storage/statestore/stores/run_store.py
+++ b/fedn/network/storage/statestore/stores/run_store.py
@@ -29,7 +29,7 @@ class MongoDBRunStore(RunStore, MongoDBStore[RunDTO]):
 
 class SQLRunStore(RunStore, SQLStore[RunDTO, RunModel]):
     def __init__(self, session):
-        super().__init__(session, RunModel)
+        super().__init__(session, RunModel, "training_run_id")
 
     def _update_orm_model_from_dto(self, entity: RunModel, item: RunDTO):
         item_dict = item.to_db(exclude_unset=False)

--- a/fedn/network/storage/statestore/stores/session_store.py
+++ b/fedn/network/storage/statestore/stores/session_store.py
@@ -32,7 +32,7 @@ class MongoDBSessionStore(SessionStore, MongoDBStore[SessionDTO]):
 
 class SQLSessionStore(SessionStore, SQLStore[SessionDTO, SessionModel]):
     def __init__(self, Session):
-        super().__init__(Session, SessionModel)
+        super().__init__(Session, SessionModel, "session_id")
 
     def update(self, item: SessionDTO) -> SessionDTO:
         return self.sql_update(item)

--- a/fedn/network/storage/statestore/stores/status_store.py
+++ b/fedn/network/storage/statestore/stores/status_store.py
@@ -50,7 +50,7 @@ def _translate_key_sql(key: str) -> str:
 
 class SQLStatusStore(StatusStore, SQLStore[StatusDTO, StatusModel]):
     def __init__(self, Session):
-        super().__init__(Session, StatusModel)
+        super().__init__(Session, StatusModel, "status_id")
 
     def list(self, limit: int, skip: int, sort_key: str, sort_order=SortOrder.DESCENDING, **kwargs):
         kwargs = {_translate_key_sql(k): v for k, v in kwargs.items()}

--- a/fedn/network/storage/statestore/stores/validation_store.py
+++ b/fedn/network/storage/statestore/stores/validation_store.py
@@ -43,7 +43,7 @@ def _translate_key_sql(key: str) -> str:
 
 class SQLValidationStore(ValidationStore, SQLStore[ValidationDTO, ValidationModel]):
     def __init__(self, Session):
-        super().__init__(Session, ValidationModel)
+        super().__init__(Session, ValidationModel, "validation_id")
 
     def list(self, limit: int, skip: int, sort_key: str, sort_order=SortOrder.DESCENDING, **kwargs):
         kwargs = {_translate_key_sql(k): v for k, v in kwargs.items()}

--- a/fedn/tests/stores/test_client_store.py
+++ b/fedn/tests/stores/test_client_store.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+from typing import List
 import uuid
 
 import pytest
@@ -30,7 +31,7 @@ def test_client():
     return c
 
 @pytest.fixture
-def db_connections_with_data(postgres_connection:DatabaseConnection, sql_connection: DatabaseConnection, mongo_connection:DatabaseConnection, test_clients):
+def db_connections_with_data(postgres_connection:DatabaseConnection, sql_connection: DatabaseConnection, mongo_connection:DatabaseConnection, test_clients: List[ClientDTO]):
     for c in test_clients:
         mongo_connection.client_store.add(c)
         postgres_connection.client_store.add(c)
@@ -52,7 +53,8 @@ def options():
                     "client_id",
                     "last_seen",
                     "ip", # None unique key 
-                    "invalid_key"
+                    "invalid_key",
+                    "committed_at"
                     ) 
     limits = (None, 0, 1, 2, 99)
     skips = (None, 0, 1, 2, 99)


### PR DESCRIPTION
Changed the default ordering to sort on commited_at desc instead of id as before