### PR TITLE
Feature/SK-1563 | Remove the active model concept

### DIFF
--- a/fedn/cli/session_cmd.py
+++ b/fedn/cli/session_cmd.py
@@ -87,10 +87,21 @@ def start_session(
         headers = {"Authorization": _token}
 
     if model_id is None:
-        url = get_api_url(protocol, host, port, "models/active", usr_api=False)
-        response = requests.get(url, headers=headers)
+        model_query_headers = headers.copy()
+        model_query_headers["X-Limit"] = "1"
+        model_query_headers["X-Sort-Key"] = "committed_at"
+        model_query_headers["X-Sort-Order"] = "desc"
+
+        url = get_api_url(protocol, host, port, "models", usr_api=False)
+        response = requests.get(url, headers=model_query_headers)
         if response.status_code == 200:
-            model_id = response.json()
+            json = response.json()
+
+            if "result" in json and len(json["result"]) > 0:
+                model_id = json["result"][0]["model_id"]
+            else:
+                click.secho("No models found", fg="red")
+                return
         else:
             click.secho(f"Failed to get active model: {response.json()}", fg="red")
             return

--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -640,9 +640,17 @@ class APIClient:
         :rtype: dict
         """
         if model_id is None:
-            response = requests.get(self._get_url_api_v1("models/active"), verify=self.verify, headers=self.headers)
+            headers = self.headers.copy()
+            headers["X-Limit"] = "1"
+            headers["X-Sort-Key"] = "committed_at"
+            headers["X-Sort-Order"] = "desc"
+            response = requests.get(self._get_url_api_v1("models"), verify=self.verify, headers=headers)
             if response.status_code == 200:
-                model_id = response.json()
+                json = response.json()
+                if "result" in json and len(json["result"]) > 0:
+                    model_id = json["result"][0]["model_id"]
+                else:
+                    return {"message": "No models found in the repository"}
             else:
                 return response.json()
 

--- a/fedn/network/api/client.py
+++ b/fedn/network/api/client.py
@@ -269,6 +269,8 @@ class APIClient:
         """
         _headers = self.headers.copy()
         _headers["X-Limit"] = "1"
+        _headers["X-Sort-Key"] = "committed_at"
+        _headers["X-Sort-Order"] = "desc"
 
         response = requests.get(self._get_url_api_v1("models/"), verify=self.verify, headers=_headers)
         _json = response.json()

--- a/fedn/network/api/server.py
+++ b/fedn/network/api/server.py
@@ -356,7 +356,7 @@ if custom_url_prefix:
 @jwt_auth_required(role="admin")
 def get_latest_model():
     response = {
-        "message": "This endpoint is deprecated. Use /api/v1/models/active instead.",
+        "message": "This endpoint is deprecated. Use /api/v1/models instead.",
     }
     return jsonify(response), 410
 
@@ -369,7 +369,7 @@ if custom_url_prefix:
 @jwt_auth_required(role="admin")
 def set_current_model():
     response = {
-        "message": "This endpoint is deprecated. Use /api/v1/models/active instead.",
+        "message": "This endpoint is deprecated. Use /api/v1/models instead.",
     }
     return jsonify(response), 410
 
@@ -382,7 +382,7 @@ if custom_url_prefix:
 @jwt_auth_required(role="admin")
 def get_initial_model():
     response = {
-        "message": "This endpoint is deprecated. Use /api/v1/models/active instead.",
+        "message": "This endpoint is deprecated. Use /api/v1/models instead.",
     }
     return jsonify(response), 410
 

--- a/fedn/network/api/v1/model_routes.py
+++ b/fedn/network/api/v1/model_routes.py
@@ -775,84 +775,6 @@ def get_parameters(id: str):
         return jsonify({"message": "An unexpected error occurred"}), 500
 
 
-@bp.route("/active", methods=["GET"])
-@jwt_auth_required(role="admin")
-def get_active_model():
-    """Get active model
-    Retrieves the active model (id).
-    ---
-    tags:
-        - Models
-    responses:
-        200:
-            description: The active model id
-            schema:
-                type: string
-        500:
-            description: An error occurred
-            schema:
-                type: object
-                properties:
-                    message:
-                        type: string
-    """
-    try:
-        db = Control.instance().db
-        active_model = db.model_store.get_active()
-        if active_model is None:
-            return jsonify({"message": "No active model found"}), 404
-
-        response = active_model
-
-        return jsonify(response), 200
-    except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
-        return jsonify({"message": "An unexpected error occurred"}), 500
-
-
-@bp.route("/active", methods=["PUT"])
-@jwt_auth_required(role="admin")
-def set_active_model():
-    """Set active model
-    Sets the active model (id).
-    ---
-    tags:
-        - Models
-    parameters:
-      - name: model
-        in: body
-        required: true
-        type: object
-        description: The model data to update
-    responses:
-        200:
-            description: The updated active model id
-            schema:
-                type: string
-        500:
-            description: An error occurred
-            schema:
-                type: object
-                properties:
-                    message:
-                        type: string
-    """
-    try:
-        db = Control.instance().db
-        data = request.get_json()
-        model_id = data["id"]
-
-        response = db.model_store.set_active(model_id)
-
-        if response:
-            return jsonify({"message": "Active model set"}), 200
-        else:
-            return jsonify({"message": "Failed to set active model"}), 500
-    except Exception as e:
-        logger.error(f"An unexpected error occurred: {e}")
-        return jsonify({"message": "An unexpected error occurred"}), 500
-
-
 @bp.route("/", methods=["POST"])
 @jwt_auth_required(role="admin")
 def upload_model():
@@ -895,7 +817,7 @@ def upload_model():
             logger.info(f"Loading model from file using helper {helper.name}")
             object.seek(0)
             model = helper.load(object)
-            control.commit(model_id=None, model=model, name=name)
+            control.commit(model=model, name=name)
         except Exception as e:
             logger.error(f"An unexpected error occurred: {e}")
             status_code = 400

--- a/fedn/network/api/v1/model_routes.py
+++ b/fedn/network/api/v1/model_routes.py
@@ -840,3 +840,27 @@ def upload_model():
     except Exception as e:
         logger.error(f"An unexpected error occurred: {e}")
         return jsonify({"message": "An unexpected error occurred"}), 500
+
+
+# deprecated
+
+
+@bp.route("/active", methods=["GET"])
+@jwt_auth_required(role="admin")
+def get_active_model():
+    return jsonify(
+        {
+            "error": "This endpoint has been deprecated and is no longer available."
+            + "The active model concept is no longer used in Fedn. Please use the /models endpoint to retrieve models.",
+        }
+    ), 410
+
+
+@bp.route("/active", methods=["PUT"])
+@jwt_auth_required(role="admin")
+def set_active_model():
+    return jsonify(
+        {
+            "error": "This endpoint has been deprecated and is no longer available." + "The active model concept is no longer used in Fedn.",
+        }
+    ), 410

--- a/fedn/network/api/v1/model_routes.py
+++ b/fedn/network/api/v1/model_routes.py
@@ -861,6 +861,6 @@ def get_active_model():
 def set_active_model():
     return jsonify(
         {
-            "error": "This endpoint has been deprecated and is no longer available." + "The active model concept is no longer used in Fedn.",
+            "error": "This endpoint has been deprecated and is no longer available. " + "The active model concept is no longer used in Fedn.",
         }
     ), 410

--- a/fedn/network/controller/control.py
+++ b/fedn/network/controller/control.py
@@ -1,7 +1,6 @@
 import copy
 import datetime
 import time
-import uuid
 from typing import Optional
 
 from tenacity import retry, retry_if_exception_type, stop_after_delay, wait_random

--- a/fedn/network/storage/statestore/stores/model_store.py
+++ b/fedn/network/storage/statestore/stores/model_store.py
@@ -44,23 +44,6 @@ class ModelStore(Store[ModelDTO]):
         """
         pass
 
-    @abstractmethod
-    def get_active(self) -> str:
-        """Get the active model
-        return: The active model id (str)
-        """
-        pass
-
-    @abstractmethod
-    def set_active(self, id: str) -> bool:
-        """Set the active model
-        param id: The id of the entity
-            type: str
-            description: The id of the entity, can be either the id or the model (property)
-        return: True if successful
-        """
-        pass
-
 
 class MongoDBModelStore(ModelStore, MongoDBStore[ModelDTO]):
     def __init__(self, database: Database, collection: str):
@@ -166,31 +149,6 @@ class MongoDBModelStore(ModelStore, MongoDBStore[ModelDTO]):
 
         return result
 
-    def get_active(self) -> str:
-        active_model = self.database[self.collection].find_one({"key": "current_model"})
-
-        if active_model is None:
-            return None
-
-        return active_model["model"]
-
-    def set_active(self, id: str) -> bool:
-        kwargs = {"key": "models"}
-        if ObjectId.is_valid(id):
-            id_obj = ObjectId(id)
-            kwargs["_id"] = id_obj
-        else:
-            kwargs["model"] = id
-
-        model = self.database[self.collection].find_one(kwargs)
-
-        if model is None:
-            return False
-
-        self.database[self.collection].update_one({"key": "current_model"}, {"$set": {"model": model["model"]}}, upsert=True)
-
-        return True
-
     def _document_from_dto(self, item: ModelDTO) -> Dict:
         item_dict = item.to_db(exclude_unset=False)
         item_dict["model"] = item_dict.pop("model_id")
@@ -268,29 +226,6 @@ class SQLModelStore(ModelStore, SQLStore[ModelDTO, ModelModel]):
                 result.append(self._dto_from_orm_model(item))
 
             return result
-
-    def get_active(self) -> str:
-        with self.Session() as session:
-            active_stmt = select(ModelModel).where(ModelModel.active)
-            active_item = session.scalars(active_stmt).first()
-            if active_item:
-                return active_item.id
-            return None
-
-    def set_active(self, id: str) -> bool:
-        with self.Session() as session:
-            stmt = select(ModelModel).where(ModelModel.id == id)
-            item = session.scalars(stmt).first()
-            if item is None:
-                return False
-
-            active_stmt = select(ModelModel).where(ModelModel.active)
-            active_items = session.scalars(active_stmt).all()
-            for item in active_items:
-                item.active = False
-            item.active = True
-            session.commit()
-        return True
 
     def _update_orm_model_from_dto(self, entity: ModelModel, item: ModelDTO):
         item_dict = item.to_db(exclude_unset=False)

--- a/fedn/network/storage/statestore/stores/model_store.py
+++ b/fedn/network/storage/statestore/stores/model_store.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 from typing import Dict, List
 
-from bson import ObjectId
 from pymongo.database import Database
 from sqlalchemy import select
 from sqlalchemy.orm import aliased


### PR DESCRIPTION
This pull request introduces significant changes to the model management system in the `fedn` repository, primarily focusing on the removal of the "active model" concept and replacing it with a more flexible model querying mechanism. Additionally, it simplifies the codebase by removing deprecated methods and endpoints, and refactors several functions to align with these updates.

### Model Management Updates:
* Replaced the "active model" concept with a query-based approach that retrieves the most recently committed model using headers like `X-Sort-Key` and `X-Sort-Order`. This change impacts `start_session` in both `fedn/cli/session_cmd.py` and `fedn/network/api/client.py`.

### Deprecation of "Active Model" Endpoints:
* Removed the `/active` endpoints for getting and setting the active model in `fedn/network/api/v1/model_routes.py`. These endpoints now return a 410 status with a deprecation message.
* Updated messages in deprecated endpoints in `fedn/network/api/server.py` to direct users to the `/models` endpoint instead.

### Refactoring and Cleanup:
* Removed the `get_active` and `set_active` methods from model store implementations, including `MongoDBModelStore` and SQLAlchemy-based stores, as they are no longer needed.
* Simplified the `commit` method in `fedn/network/controller/control.py` by removing redundant UUID generation and directly returning the committed model ID. 

### Minor Adjustments:
* Removed unused imports, such as `uuid` and `ObjectId`, from various files to clean up the codebase.