### PR TITLE
Fix/SK-1632 | Add compressed file suffix to .fednignore + output path option

### DIFF
--- a/examples/FedSimSiam/client/.fednignore
+++ b/examples/FedSimSiam/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .fedsimsiam
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/flower-client/client/.fednignore
+++ b/examples/flower-client/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .flower-client
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/huggingface/client/.fednignore
+++ b/examples/huggingface/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .huggingface
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/mnist-keras/client/.fednignore
+++ b/examples/mnist-keras/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .mnist-keras
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/mnist-pytorch-DPSGD/client/.fednignore
+++ b/examples/mnist-pytorch-DPSGD/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .mnist-pytorch
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/mnist-pytorch/client/.fednignore
+++ b/examples/mnist-pytorch/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .mnist-pytorch
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/monai-2D-mednist/client/.fednignore
+++ b/examples/monai-2D-mednist/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .monai-2d-mdnist
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/server-functions/client/.fednignore
+++ b/examples/server-functions/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .mnist-pytorch
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/splitlearning_diabetes/client/.fednignore
+++ b/examples/splitlearning_diabetes/client/.fednignore
@@ -1,2 +1,6 @@
 __pycache__
+.splitlearning
 data
+*.tgz
+*.tar.gz
+*.zip

--- a/examples/welding-defect-detection/client/.fednignore
+++ b/examples/welding-defect-detection/client/.fednignore
@@ -1,3 +1,6 @@
 __pycache__
 .welding-defect-detection
 data
+*.tgz
+*.tar.gz
+*.zip


### PR DESCRIPTION
Fixes ptoblem where the "fedn package create --path client" creates the compressed file into "client" folder. Add option to specify output path, default to CWD. 