### PR TITLE
Feature/SK-1717 | Start combiner server if run as __main__

### DIFF
--- a/config/settings-combiner.yaml.local.template
+++ b/config/settings-combiner.yaml.local.template
@@ -5,6 +5,8 @@ host: localhost
 address: localhost
 port: 12080
 max_clients: 30
+fqdn:
+secure: false
 
 cert_path: tmp/server.crt
 key_path: tmp/server.key

--- a/config/settings-combiner.yaml.template
+++ b/config/settings-combiner.yaml.template
@@ -6,6 +6,8 @@ name: combiner
 host: combiner
 port: 12080
 max_clients: 30
+fqdn:
+secure: false
 
 statestore:
   # Available DB types are MongoDB, PostgreSQL, SQLite

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,6 +87,7 @@ services:
       - MODELSTORAGE_CONFIG=/app/config/settings-combiner.yaml.template
       - HOOK_SERVICE_HOST=hook:12081
       - TMPDIR=/app/tmp
+      - FEDN_COMBINER_CONFIG=/app/config/settings-combiner.yaml.template
     build:
       context: .
       args:
@@ -95,11 +96,9 @@ services:
     working_dir: /app
     volumes:
       - ${HOST_REPO_DIR:-.}/fedn:/app/fedn
+    entrypoint: ["sh", "-c"]
     command:
-      - combiner
-      - start
-      - --init
-      - config/settings-combiner.yaml.template
+      - "/venv/bin/python /app/fedn/network/combiner/combiner.py"
     ports:
       - 12080:12080
     healthcheck:

--- a/fedn/common/config.py
+++ b/fedn/common/config.py
@@ -34,6 +34,7 @@ FEDN_OBJECT_STORAGE_BUCKETS = {
     "context": os.environ.get("FEDN_OBJECT_CONTEXT_BUCKET", "fedn-context"),
     "prediction": os.environ.get("FEDN_OBJECT_PREDICTION_BUCKET", "fedn-prediction"),
 }
+FEDN_COMBINER_CONFIG = os.environ.get("FEDN_COMBINER_CONFIG", os.path.join(os.path.expanduser("~"), ".fedn", "combiner.yaml"))
 
 
 def get_environment_config():


### PR DESCRIPTION
This pull request introduces several configuration and startup changes for the combiner service, focusing on how it loads configuration files, sets environment variables, and starts the service process. The changes improve flexibility and standardization in configuration management and service initialization.

**Configuration management improvements:**

* Added support for specifying the combiner configuration file path via the `FEDN_COMBINER_CONFIG` environment variable in `fedn/common/config.py`, with a default fallback location.
* Updated the combiner YAML templates (`config/settings-combiner.yaml.local.template` and `config/settings-combiner.yaml.template`) to include new fields `fqdn` and `secure` for more flexible network configuration. [[1]](diffhunk://#diff-b26a1a1c2451c1b6dc180d76d4c2e7007c71431fec560d6fc0271a420b809ea9R8-R9) [[2]](diffhunk://#diff-b2da2169045cc1c13859685bb714b63b64c45401acbd1adf83aba8cc771fe1fcR9-R10)

**Service startup and Docker integration:**

* Modified the combiner service entrypoint in `docker-compose.yaml` to start the combiner using a Python script (`combiner.py`) instead of the previous CLI command, and added the `FEDN_COMBINER_CONFIG` environment variable to the container environment. [[1]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R90) [[2]](diffhunk://#diff-3fde9d1a396e140fefc7676e1bd237d67b6864552b6f45af1ebcc27bcd0bb6e9R99-R101)
* Refactored `fedn/network/combiner/combiner.py` to load configuration from the file specified by `FEDN_COMBINER_CONFIG`, validate its existence, and initialize the service using the loaded configuration. [[1]](diffhunk://#diff-ef69b399917218afadbf6931e5791eac521bcb7623789475cf0437d32534e31eR2) [[2]](diffhunk://#diff-ef69b399917218afadbf6931e5791eac521bcb7623789475cf0437d32534e31eR13-R19) [[3]](diffhunk://#diff-ef69b399917218afadbf6931e5791eac521bcb7623789475cf0437d32534e31eR965-R985)