### PR TITLE
Drop references to develop branch

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ Checklist
 If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
 This is simply a reminder of what we are going to look for before merging your code.
 
-- This PR is against **develop** branch (not applicable for hotfixes)
+- This PR is against **master** branch
 - You have included a link to the issue on GitHub or JIRA (if any)
 - You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
 - You have included tests to complement my changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,12 +22,12 @@ Report a bug or propose a feature by [opening a new GitHub Issue](https://github
 ### Branches & Pull Requests
 
 - **master** branch has the latest release of FEDn
-- **develop** branch is where we add functionality and submit bugfixes
+- **master** branch is where we add functionality and submit bugfixes
 - if your branch introduces new functionality, name it **feature/[GitHub-Issue-ID]**
 - if your branch resolves a bug, name it **issue/[GitHub-Issue-ID]**
 - if your branch is a hotfix, name it **hotfix/[GitHub-Issue-ID]**
 
-Open your pull requests against the **develop** branch unless you're resolving a critical bug in production (hotfix). Then your pull request should be against **master** branch.
+Open your pull requests against the **master** branch.
 
 ### Code checks
 We defined GitHub actions that check code quality and formatting against pushed branches and pull requests. We use:


### PR DESCRIPTION
## Description

The develop branch has been abandoned for two years. All changes appear to go to master.

<!--
Checklist
---------
If you're unsure about any of the items below, don't hesitate to ask. We're here to help! 
This is simply a reminder of what we are going to look for before merging your code.

- This PR is against **develop** branch (not applicable for hotfixes)
- You have included a link to the issue on GitHub or JIRA (if any)
- You have read the [CONTRIBUTING](https://github.com/scaleoutsystems/fedn/blob/master/CONTRIBUTING.md) doc
- You have included tests to complement my changes
- You have updated the related documentation (if necessary) 
- You have added a reviewer for this pull request
-->