### PR TITLE
Fix/SK-1792 | Fix start_splitlearning_session call

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -25,7 +25,7 @@ jobs:
           - "mnist-keras numpyhelper"
           - "mnist-pytorch numpyhelper"
           - "server-functions numpyhelper"
-        python_version: ["3.9", "3.10", "3.11", "3.12"]
+        python_version: ["3.10", "3.11", "3.12"]
         os:
           - ubuntu-24.04
     runs-on: ${{ matrix.os }}

--- a/fedn/network/api/v1/session_routes.py
+++ b/fedn/network/api/v1/session_routes.py
@@ -484,6 +484,16 @@ def start_splitlearning_session():
         rounds: int = data.get("rounds", "")
         round_timeout: int = data.get("round_timeout", None)
         model_name_prefix: str = data.get("model_name_prefix", None)
+        client_ids: str = data.get("client_ids", None)
+
+        if client_ids is not None and not isinstance(client_ids, str):
+            return jsonify({"message": "client_ids must be a comma separated string"}), 400
+        if client_ids is not None:
+            client_ids: list[str] = client_ids.split(",")
+            if len(client_ids) == 0:
+                return jsonify({"message": "client_ids must be a comma separated string"}), 400
+            if any(not isinstance(client_id, str) for client_id in client_ids):
+                return jsonify({"message": "client_ids must be a comma separated string"}), 400
 
         if model_name_prefix is None or not isinstance(model_name_prefix, str) or len(model_name_prefix) == 0:
             model_name_prefix = None
@@ -500,7 +510,7 @@ def start_splitlearning_session():
 
         if not rounds or not isinstance(rounds, int):
             rounds = session_config.rounds
-        nr_available_clients = _get_number_of_available_clients()
+        nr_available_clients = _get_number_of_available_clients(client_ids=client_ids)
 
         if nr_available_clients < min_clients:
             return jsonify({"message": f"Number of available clients is lower than the required minimum of {min_clients}"}), 400


### PR DESCRIPTION
A new input parameter has been added to the _get_number_of_available_clients function in session_routes.py.
This has not been updated in the start_splitlearning_session call.
This PR fixes it.